### PR TITLE
fix(commands): simplify allowed-tools pattern for check-usage

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Comprehensive status line with context usage, API rate limits, and cost tracking",
-    "version": "1.8.0"
+    "version": "1.8.1"
   },
   "plugins": [
     {
@@ -24,5 +24,5 @@
       ]
     }
   ],
-  "version": "1.8.0"
+  "version": "1.8.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-dashboard",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Comprehensive status line with context usage, API rate limits, and cost tracking",
   "author": {
     "name": "uppinote"

--- a/commands/check-usage.md
+++ b/commands/check-usage.md
@@ -1,6 +1,6 @@
 ---
 description: Check all AI CLI (Claude, Codex, Gemini, z.ai) usage limits and get recommendations
-allowed-tools: Bash(node:*)
+allowed-tools: Bash
 ---
 
 # Check CLI Usage

--- a/dist/check-usage.js
+++ b/dist/check-usage.js
@@ -66,7 +66,7 @@ function hashToken(token) {
 }
 
 // scripts/version.ts
-var VERSION = "1.8.0";
+var VERSION = "1.8.1";
 
 // scripts/utils/api-client.ts
 var API_TIMEOUT_MS = 5e3;

--- a/dist/index.js
+++ b/dist/index.js
@@ -145,7 +145,7 @@ function hashToken(token) {
 }
 
 // scripts/version.ts
-var VERSION = "1.8.0";
+var VERSION = "1.8.1";
 
 // scripts/utils/api-client.ts
 var API_TIMEOUT_MS = 5e3;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-dashboard",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "type": "module",
   "description": "Comprehensive status line with context usage, API rate limits, and cost tracking",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- check-usage 명령어에서 권한 프롬프트 없이 자동 실행되도록 수정
- `allowed-tools: Bash(node:*)` → `allowed-tools: Bash`로 변경
- shell expansion 포함 명령어에서 패턴 매칭이 동작하지 않는 문제 해결

## Test plan
- [ ] `/claude-dashboard:check-usage` 실행 시 권한 프롬프트 없이 바로 실행 확인