### PR TITLE
feat: extend model widget with Sonnet effort level and Opus fast mode

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Comprehensive status line with context usage, API rate limits, and cost tracking",
-    "version": "1.10.1"
+    "version": "1.11.0"
   },
   "plugins": [
     {
@@ -24,5 +24,5 @@
       ]
     }
   ],
-  "version": "1.10.1"
+  "version": "1.11.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-dashboard",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "description": "Comprehensive status line with context usage, API rate limits, and cost tracking",
   "author": {
     "name": "uppinote"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ interface Widget<T extends WidgetData> {
 
 | Widget ID | Data Source | Description |
 |-----------|-------------|-------------|
-| `model` | stdin + settings | Model name with emoji, effort level for Opus (H/M/L) |
+| `model` | stdin + settings | Model name with emoji, effort level for Opus/Sonnet (H/M/L), fast mode for Opus (↯) |
 | `context` | stdin | Progress bar, %, tokens |
 | `cost` | stdin | Session cost |
 | `rateLimit5h` | API | 5-hour rate limit |

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Multi-provider support: z.ai/ZHIPU, Codex, Gemini auto-detected when installed.
 
 | Category | Widget | Description |
 |----------|--------|-------------|
-| **Core** | `model` | Model name with emoji, effort level for Opus (H/M/L) |
+| **Core** | `model` | Model name with emoji, effort level for Opus/Sonnet (H/M/L), fast mode for Opus (↯) |
 | | `context` | Progress bar, percentage, tokens (🟢 0-50% / 🟡 51-80% / 🔴 81-100%) |
 | | `cost` | Session cost in USD |
 | | `projectInfo` | Directory name + git branch (`*` if dirty) |

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -39,7 +39,7 @@ Configure the claude-dashboard status line plugin with widget system support.
 
 | Widget | Description |
 |--------|-------------|
-| `model` | Model name with emoji |
+| `model` | Model name with emoji, effort level (Opus/Sonnet), fast mode (Opus) |
 | `context` | Progress bar, percentage, tokens |
 | `cost` | Session cost in USD |
 | `rateLimit5h` | 5-hour rate limit |
@@ -136,18 +136,18 @@ Display what the status line will look like based on their configuration:
 
 **Compact (1 line) - Default:**
 ```
-🤖 Opus │ ████████░░ 80% │ 160K/200K │ $1.25 │ 5h: 42% (2h30m) │ 7d: 69% │ 7d-S: 2%
+🤖 Opus(H) │ ████████░░ 80% │ 160K/200K │ $1.25 │ 5h: 42% (2h30m) │ 7d: 69% │ 7d-S: 2%
 ```
 
 **Normal (2 lines):**
 ```
-🤖 Opus │ ████████░░ 80% │ 160K/200K │ $1.25 │ 5h: 42% (2h30m) │ 7d: 69% │ 7d-S: 2%
+🤖 Opus(H) ↯ │ ████████░░ 80% │ 160K/200K │ $1.25 │ 5h: 42% (2h30m) │ 7d: 69% │ 7d-S: 2%
 📁 project (main) │ 🔑 abc12345 │ ⏱ 45m │ 🔥 5K/m │ ✓ 3/5
 ```
 
 **Detailed (4 lines):**
 ```
-🤖 Opus │ ████████░░ 80% │ 160K/200K │ $1.25 │ 5h: 42% (2h30m) │ 7d: 69% │ 7d-S: 2%
+🤖 Opus(H) ↯ │ ████████░░ 80% │ 160K/200K │ $1.25 │ 5h: 42% (2h30m) │ 7d: 69% │ 7d-S: 2%
 📁 project (main) │ 🔑 abc12345 │ ⏱ 45m │ 🔥 5K/m │ ⏳ 2h15m │ ✓ 3/5
 CLAUDE.md: 2 │ ⚙️ 12 done │ 🤖 Agent: 1 │ 📦 85%
 🔷 gpt-5.2-codex │ 5h: 15% │ 7d: 5% │ 💎 gemini-2.0-flash │ 0% (23h59m) │ 🟠 GLM │ 5h: 23% │ 1m: 45%

--- a/dist/check-usage.js
+++ b/dist/check-usage.js
@@ -66,7 +66,7 @@ function hashToken(token) {
 }
 
 // scripts/version.ts
-var VERSION = "1.10.1";
+var VERSION = "1.11.0";
 
 // scripts/utils/api-client.ts
 var API_TIMEOUT_MS = 5e3;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-dashboard",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "type": "module",
   "description": "Comprehensive status line with context usage, API rate limits, and cost tracking",
   "main": "dist/index.js",

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -208,6 +208,7 @@ export interface ModelData {
   id: string;
   displayName: string;
   effortLevel: EffortLevel;
+  fastMode: boolean;
 }
 
 export interface ContextData {

--- a/scripts/widgets/model.ts
+++ b/scripts/widgets/model.ts
@@ -1,5 +1,8 @@
 /**
- * Model widget - displays current Claude model name with effort level
+ * Model widget - displays current Claude model name with effort level and fast mode
+ *
+ * Effort level: Shown for Opus and Sonnet (H/M/L), hidden for Haiku
+ * Fast mode: Opus 4.6 exclusive feature, indicated by ↯ symbol
  */
 
 import { readFile, stat } from 'fs/promises';
@@ -17,33 +20,41 @@ function isEffortLevel(value: unknown): value is EffortLevel {
   return typeof value === 'string' && EFFORT_LEVELS.has(value);
 }
 
-let settingsCache: { mtime: number; effortLevel: EffortLevel } | null = null;
+interface ModelSettings {
+  effortLevel: EffortLevel;
+  fastMode: boolean;
+}
 
-async function getEffortLevel(): Promise<EffortLevel> {
+const DEFAULT_SETTINGS: ModelSettings = { effortLevel: 'high', fastMode: false };
+
+let settingsCache: (ModelSettings & { mtime: number }) | null = null;
+
+async function getModelSettings(): Promise<ModelSettings> {
   const settingsPath = join(homedir(), '.claude', 'settings.json');
 
   try {
     const fileStat = await stat(settingsPath);
     if (settingsCache && settingsCache.mtime === fileStat.mtimeMs) {
-      return settingsCache.effortLevel;
+      return { effortLevel: settingsCache.effortLevel, fastMode: settingsCache.fastMode };
     }
     const content = await readFile(settingsPath, 'utf-8');
     const settings = JSON.parse(content);
-    const level: EffortLevel = isEffortLevel(settings.effortLevel)
+    const effortLevel: EffortLevel = isEffortLevel(settings.effortLevel)
       ? settings.effortLevel
       : 'high';
-    settingsCache = { mtime: fileStat.mtimeMs, effortLevel: level };
-    return level;
+    const fastMode = settings.fastMode === true;
+    settingsCache = { mtime: fileStat.mtimeMs, effortLevel, fastMode };
+    return { effortLevel, fastMode };
   } catch {
     settingsCache = null;
   }
 
   const envEffort = process.env.CLAUDE_CODE_EFFORT_LEVEL;
   if (isEffortLevel(envEffort)) {
-    return envEffort;
+    return { effortLevel: envEffort, fastMode: false };
   }
 
-  return 'high';
+  return DEFAULT_SETTINGS;
 }
 
 export const modelWidget: Widget<ModelData> = {
@@ -52,12 +63,13 @@ export const modelWidget: Widget<ModelData> = {
 
   async getData(ctx: WidgetContext): Promise<ModelData | null> {
     const { model } = ctx.stdin;
-    const effortLevel = await getEffortLevel();
+    const { effortLevel, fastMode } = await getModelSettings();
 
     return {
       id: model?.id || '',
       displayName: model?.display_name || '-',
       effortLevel,
+      fastMode,
     };
   },
 
@@ -65,11 +77,15 @@ export const modelWidget: Widget<ModelData> = {
     const shortName = shortenModelName(data.displayName);
     const icon = isZaiProvider() ? '🟠' : '🤖';
 
-    // Show effort suffix for Opus: (H), (M), (L)
-    const effortSuffix = shortName === 'Opus'
+    // Show effort suffix for Opus and Sonnet: (H), (M), (L). Haiku excluded.
+    const supportsEffort = shortName === 'Opus' || shortName === 'Sonnet';
+    const effortSuffix = supportsEffort
       ? `(${data.effortLevel[0].toUpperCase()})`
       : '';
 
-    return `${COLORS.pastelCyan}${icon} ${shortName}${effortSuffix}${RESET}`;
+    // Fast mode indicator (Opus 4.6 exclusive)
+    const fastIndicator = shortName === 'Opus' && data.fastMode ? ' ↯' : '';
+
+    return `${COLORS.pastelCyan}${icon} ${shortName}${effortSuffix}${fastIndicator}${RESET}`;
   },
 };


### PR DESCRIPTION
## Summary
- Effort level(H/M/L)을 Opus뿐 아니라 **Sonnet 4.6에도 표시** (Haiku 제외)
- Opus 전용 **fast mode 표시** (↯ 기호, `settings.json`의 `fastMode` 읽기)
- `getEffortLevel()` → `getModelSettings()` 리네이밍, `ModelSettings` 인터페이스 추출
- 모델별 effort/fast mode 테스트 6개 추가 (총 234 tests pass)
- 문서 업데이트 (CLAUDE.md, README.md, setup.md)

## Output examples

| Model | Effort | Fast | Output |
|-------|--------|------|--------|
| Opus | high | off | `🤖 Opus(H)` |
| Opus | medium | on | `🤖 Opus(M) ↯` |
| Sonnet | low | off | `🤖 Sonnet(L)` |
| Haiku | - | - | `🤖 Haiku` |

## Test plan
- [x] `npm run build` 성공
- [x] `npm test` 234 tests pass
- [x] Opus/Sonnet effort 표시 확인
- [x] Haiku effort 미표시 확인
- [x] Opus fast mode ↯ 표시 확인
- [x] Sonnet/Haiku fast mode 미표시 확인