### PR TITLE
docs: improve setup interactive flow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Comprehensive status line with context usage, API rate limits, and cost tracking",
-    "version": "1.12.1"
+    "version": "1.12.2"
   },
   "plugins": [
     {
@@ -24,5 +24,5 @@
       ]
     }
   ],
-  "version": "1.12.1"
+  "version": "1.12.2"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-dashboard",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "Comprehensive status line with context usage, API rate limits, and cost tracking",
   "author": {
     "name": "uppinote"

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -67,25 +67,21 @@ Configure the claude-dashboard status line plugin with widget system support.
 
 **If no arguments provided (interactive mode):**
 
-Use AskUserQuestion to ask the user:
+Use AskUserQuestion to ask the user. Batch independent questions into a single AskUserQuestion call (max 4 per call) to minimize back-and-forth.
 
-1. First question: Display mode selection
-   - Options: compact (recommended), normal, detailed, custom
+**Turn 1** — Ask all 3 questions in a single AskUserQuestion call:
+1. Display mode: compact (recommended), normal, detailed, custom
+2. Theme: default (recommended), minimal, catppuccin, dracula, gruvbox
+3. Hide widgets?: No (recommended), Yes
 
-2. If "custom" selected, ask for each line:
-   - Line 1 widgets (multi-select from available widgets)
-   - Ask if they want to add Line 2
-   - If yes, Line 2 widgets (multi-select)
-   - Ask if they want to add Line 3
-   - Continue until they say no (no line limit)
-
-3. Theme selection
-   - Options: default (recommended), minimal, catppuccin, dracula, gruvbox
-
-4. Use AskUserQuestion to ask: "Do you want to hide any widgets?"
-   - Options: "No" (recommended), "Yes"
-   - If "Yes": use AskUserQuestion with multiSelect to let user pick widgets to hide from the available widgets list
-   - Set selected widgets in `"disabledWidgets"` array of config
+**Turn 2** — Conditional follow-ups (only if needed):
+- If display mode = "custom": ask for each line's widgets
+  - Line 1 widgets (multi-select from available widgets)
+  - Ask if they want to add Line 2
+  - If yes, Line 2 widgets (multi-select)
+  - Continue until they say no (no line limit)
+- If hide widgets = "Yes": ask which widgets to hide (multi-select from available widgets)
+- If both are needed, ask them together in a single AskUserQuestion call
 
 **If arguments provided (direct mode):**
 

--- a/dist/check-usage.js
+++ b/dist/check-usage.js
@@ -66,7 +66,7 @@ function hashToken(token) {
 }
 
 // scripts/version.ts
-var VERSION = "1.12.1";
+var VERSION = "1.12.2";
 
 // scripts/utils/api-client.ts
 var API_TIMEOUT_MS = 5e3;

--- a/dist/index.js
+++ b/dist/index.js
@@ -316,7 +316,7 @@ function hashToken(token) {
 }
 
 // scripts/version.ts
-var VERSION = "1.12.1";
+var VERSION = "1.12.2";
 
 // scripts/utils/api-client.ts
 var API_TIMEOUT_MS = 5e3;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-dashboard",
-  "version": "1.10.0",
+  "version": "1.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-dashboard",
-      "version": "1.10.0",
+      "version": "1.12.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-dashboard",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "type": "module",
   "description": "Comprehensive status line with context usage, API rate limits, and cost tracking",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- `/claude-dashboard:setup` interactive mode에 disabledWidgets 질문 추가
- 독립적인 질문(displayMode, theme, disabledWidgets 여부)을 한 턴에 묶어서 질문
- 조건부 후속 질문(custom 라인 구성, 위젯 숨기기 선택)은 2턴째에 처리
- v1.12.2 bump

## Test plan
- [ ] `/claude-dashboard:setup` 실행 시 3개 질문이 한번에 나오는지 확인
- [ ] disabledWidgets=Yes 선택 시 위젯 선택 질문 확인
- [ ] custom 모드 선택 시 라인 구성 질문 확인