### PR TITLE
feat: add setup-alias command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Comprehensive status line with context usage, API rate limits, and cost tracking",
-    "version": "1.12.3"
+    "version": "1.13.0"
   },
   "plugins": [
     {
@@ -24,5 +24,5 @@
       ]
     }
   ],
-  "version": "1.12.3"
+  "version": "1.13.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-dashboard",
-  "version": "1.12.3",
+  "version": "1.13.0",
   "description": "Comprehensive status line with context usage, API rate limits, and cost tracking",
   "author": {
     "name": "uppinote"

--- a/README.md
+++ b/README.md
@@ -157,6 +157,20 @@ Check usage limits for all AI CLIs (Claude, Codex, Gemini, z.ai) at once and get
 
 ![check-usage](images/check-usage.png)
 
+### `/claude-dashboard:setup-alias`
+
+Add a `check-ai` shell alias to quickly check all AI CLI usage from your terminal. Supports macOS/Linux (zsh/bash) and Windows (PowerShell).
+
+```bash
+/claude-dashboard:setup-alias
+```
+
+After setup:
+```bash
+check-ai          # Pretty output
+check-ai --json   # JSON output for scripting
+```
+
 ### `/claude-dashboard:update`
 
 Update the plugin and refresh the statusLine path in settings. Run after updating via git pull or marketplace.

--- a/commands/setup-alias.md
+++ b/commands/setup-alias.md
@@ -1,0 +1,140 @@
+---
+description: Add check-ai shell alias for quick CLI usage check
+argument-hint: ""
+allowed-tools: Bash(echo:*), Bash(cat:*), Bash(grep:*), Bash(uname:*), Bash(powershell*), Read
+---
+
+# Setup Shell Alias
+
+Add a `check-ai` command to quickly check all AI CLI usage from your terminal.
+
+## What it does
+
+After setup, you can run:
+```bash
+check-ai          # Pretty output
+check-ai --json   # JSON output for scripting
+```
+
+## Tasks
+
+### 1. Detect OS and shell
+
+```bash
+uname -s
+```
+
+- `Darwin` → macOS
+- `Linux` → Linux
+- `MINGW*` or `MSYS*` → Windows Git Bash
+- Otherwise check if PowerShell is available for Windows
+
+### 2. Based on OS, add the appropriate function
+
+#### macOS / Linux (bash/zsh)
+
+**Check current shell and config file:**
+```bash
+echo $SHELL
+```
+
+- If contains `zsh` → use `~/.zshrc`
+- If contains `bash` → use `~/.bashrc`
+
+**Check if already exists:**
+```bash
+grep -q "^check-ai()" ~/.zshrc 2>/dev/null && echo "exists" || echo "not found"
+```
+
+**Function to add:**
+```bash
+# Claude Dashboard - check-ai alias
+check-ai() {
+  node "$(ls -d ~/.claude/plugins/cache/claude-dashboard/claude-dashboard/*/dist/check-usage.js 2>/dev/null | sort -V | tail -1)" "$@"
+}
+```
+
+**Add to config file (example for zsh):**
+```bash
+cat >> ~/.zshrc << 'EOF'
+
+# Claude Dashboard - check-ai alias
+check-ai() {
+  node "$(ls -d ~/.claude/plugins/cache/claude-dashboard/claude-dashboard/*/dist/check-usage.js 2>/dev/null | sort -V | tail -1)" "$@"
+}
+EOF
+```
+
+#### Windows (PowerShell)
+
+**Check if PowerShell profile exists:**
+```powershell
+powershell -Command "Test-Path $PROFILE"
+```
+
+**Check if already exists:**
+```powershell
+powershell -Command "if (Test-Path $PROFILE) { Select-String -Path $PROFILE -Pattern 'function check-ai' -Quiet } else { $false }"
+```
+
+**Function to add:**
+```powershell
+# Claude Dashboard - check-ai alias
+function check-ai {
+  $script = (Get-ChildItem "$env:USERPROFILE\.claude\plugins\cache\claude-dashboard\claude-dashboard\*\dist\check-usage.js" | Sort-Object { [version]$_.Directory.Parent.Name } | Select-Object -Last 1).FullName
+  node $script $args
+}
+```
+
+**Add to PowerShell profile:**
+```powershell
+powershell -Command "Add-Content -Path $PROFILE -Value @'
+
+# Claude Dashboard - check-ai alias
+function check-ai {
+  `$script = (Get-ChildItem \"`$env:USERPROFILE\.claude\plugins\cache\claude-dashboard\claude-dashboard\*\dist\check-usage.js\" | Sort-Object { [version]`$_.Directory.Parent.Name } | Select-Object -Last 1).FullName
+  node `$script `$args
+}
+'@"
+```
+
+### 3. Show result and next steps
+
+**If already exists:**
+```
+✓ check-ai is already configured in [config file].
+
+Usage:
+  check-ai          # Pretty output
+  check-ai --json   # JSON output for scripting
+```
+
+**If newly added:**
+```
+✓ Added check-ai to [config file].
+
+To activate now, run:
+  source ~/.zshrc   (or restart your terminal)
+
+Usage:
+  check-ai          # Pretty output
+  check-ai --json   # JSON output for scripting
+```
+
+**For Windows:**
+```
+✓ Added check-ai to PowerShell profile.
+
+To activate now:
+  Restart PowerShell or run: . $PROFILE
+
+Usage:
+  check-ai          # Pretty output
+  check-ai --json   # JSON output for scripting
+```
+
+## Notes
+
+- The function dynamically finds the latest plugin version, so it works after updates
+- Run this command again if you need to reinstall the alias
+- The alias works independently of Claude Code

--- a/dist/check-usage.js
+++ b/dist/check-usage.js
@@ -66,7 +66,7 @@ function hashToken(token) {
 }
 
 // scripts/version.ts
-var VERSION = "1.12.3";
+var VERSION = "1.13.0";
 
 // scripts/utils/api-client.ts
 var API_TIMEOUT_MS = 5e3;

--- a/dist/index.js
+++ b/dist/index.js
@@ -316,7 +316,7 @@ function hashToken(token) {
 }
 
 // scripts/version.ts
-var VERSION = "1.12.3";
+var VERSION = "1.13.0";
 
 // scripts/utils/api-client.ts
 var API_TIMEOUT_MS = 5e3;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-dashboard",
-  "version": "1.12.3",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-dashboard",
-      "version": "1.12.3",
+      "version": "1.13.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-dashboard",
-  "version": "1.12.3",
+  "version": "1.13.0",
   "type": "module",
   "description": "Comprehensive status line with context usage, API rate limits, and cost tracking",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- `check-ai` 셸 alias 설정 커맨드 추가 (`/claude-dashboard:setup-alias`)
- macOS/Linux (zsh/bash) + Windows (PowerShell) 지원
- README.md Commands 섹션에 문서 추가
- 버전 1.12.3 → 1.13.0

## Test plan
- [x] `npm run build` 성공
- [x] `check-ai` 실행 — 컬러 출력 정상
- [x] `check-ai --json` 실행 — JSON 출력 정상