### PR TITLE
fix: parse Gemini CLI model object format in settings

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Comprehensive status line with context usage, API rate limits, and cost tracking",
-    "version": "1.13.0"
+    "version": "1.13.1"
   },
   "plugins": [
     {
@@ -24,5 +24,5 @@
       ]
     }
   ],
-  "version": "1.13.0"
+  "version": "1.13.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-dashboard",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Comprehensive status line with context usage, API rate limits, and cost tracking",
   "author": {
     "name": "uppinote"

--- a/dist/check-usage.js
+++ b/dist/check-usage.js
@@ -66,7 +66,7 @@ function hashToken(token) {
 }
 
 // scripts/version.ts
-var VERSION = "1.13.0";
+var VERSION = "1.13.1";
 
 // scripts/utils/api-client.ts
 var API_TIMEOUT_MS = 5e3;
@@ -646,7 +646,7 @@ async function getGeminiSettings() {
     const json = JSON.parse(raw);
     const data = {
       cloudaicompanionProject: json?.cloudaicompanionProject,
-      selectedModel: json?.selectedModel || json?.model,
+      selectedModel: json?.selectedModel || json?.model?.name,
       auth: json?.auth
     };
     cachedSettings = { data, mtime: fileStat.mtimeMs };

--- a/dist/index.js
+++ b/dist/index.js
@@ -316,7 +316,7 @@ function hashToken(token) {
 }
 
 // scripts/version.ts
-var VERSION = "1.13.0";
+var VERSION = "1.13.1";
 
 // scripts/utils/api-client.ts
 var API_TIMEOUT_MS = 5e3;
@@ -2049,7 +2049,7 @@ async function getGeminiSettings() {
     const json = JSON.parse(raw);
     const data = {
       cloudaicompanionProject: json?.cloudaicompanionProject,
-      selectedModel: json?.selectedModel || json?.model,
+      selectedModel: json?.selectedModel || json?.model?.name,
       auth: json?.auth
     };
     cachedSettings = { data, mtime: fileStat.mtimeMs };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-dashboard",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-dashboard",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-dashboard",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "type": "module",
   "description": "Comprehensive status line with context usage, API rate limits, and cost tracking",
   "main": "dist/index.js",

--- a/scripts/utils/gemini-client.ts
+++ b/scripts/utils/gemini-client.ts
@@ -377,7 +377,7 @@ async function getGeminiSettings(): Promise<GeminiSettings | null> {
 
     const data: GeminiSettings = {
       cloudaicompanionProject: json?.cloudaicompanionProject,
-      selectedModel: json?.selectedModel || json?.model,
+      selectedModel: json?.selectedModel || json?.model?.name,
       auth: json?.auth,
     };
 


### PR DESCRIPTION
## Summary
- Gemini CLI `/model set --persist` 명령이 모델을 `{ "model": { "name": "..." } }` 객체로 저장하는데, 기존 코드가 `json?.model`로 읽어 객체 자체가 반환되는 문제 수정
- `json?.model?.name`으로 변경하여 올바른 모델명 추출

## Changes
- `scripts/utils/gemini-client.ts`: `getGeminiSettings()` 모델 파싱 로직 수정
- Version bump: 1.13.0 → 1.13.1

## Test plan
- [x] `{ "model": { "name": "gemini-2.5-pro" } }` (객체) → `💎 gemini-2.5-pro` 정상 표시
- [x] `{ "model": { "name": "gemini-2.5-flash" } }` (객체) → `💎 gemini-2.5-flash` 정상 표시
- [x] `model` 필드 없음 → 기본 모델 fallback
- [x] `npm run build` 성공
- [x] Gemini CLI 소스 확인: `setValue('model.name', model)` → 항상 객체 형태 저장

Closes #25