### PR TITLE
fix: add curl fallback when fetch gets 403 from usage API

### DIFF
--- a/dist/check-usage.js
+++ b/dist/check-usage.js
@@ -2,6 +2,7 @@
 
 // scripts/utils/api-client.ts
 import { readFile as readFile2, writeFile, mkdir, readdir, stat as stat2, unlink } from "fs/promises";
+import { execFile } from "child_process";
 import os from "os";
 import path from "path";
 
@@ -93,6 +94,7 @@ function debugLog(context, message, error) {
 }
 
 // scripts/utils/api-client.ts
+var API_URL = "https://api.anthropic.com/api/oauth/usage";
 var API_TIMEOUT_MS = 5e3;
 var MAX_RETRY_AFTER_MS = 1e4;
 var STALE_FALLBACK_SECONDS = 3600;
@@ -181,7 +183,7 @@ async function makeRequest(token) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
   try {
-    return await fetch("https://api.anthropic.com/api/oauth/usage", {
+    return await fetch(API_URL, {
       method: "GET",
       headers: {
         Accept: "application/json",
@@ -195,6 +197,46 @@ async function makeRequest(token) {
   } finally {
     clearTimeout(timeout);
   }
+}
+async function makeRequestViaCurl(token) {
+  return new Promise((resolve) => {
+    const child = execFile(
+      "curl",
+      [
+        "-s",
+        "-w",
+        "\n%{http_code}",
+        API_URL,
+        "-H",
+        "Accept: application/json",
+        "-H",
+        `User-Agent: claude-dashboard/${VERSION}`,
+        "-H",
+        `Authorization: Bearer ${token}`,
+        "-H",
+        "anthropic-beta: oauth-2025-04-20"
+      ],
+      { encoding: "utf-8", timeout: API_TIMEOUT_MS },
+      (error, stdout) => {
+        if (error) {
+          debugLog("api", "curl fallback failed", error);
+          resolve(null);
+          return;
+        }
+        try {
+          const lines = stdout.trimEnd().split("\n");
+          const statusCode = parseInt(lines[lines.length - 1], 10);
+          const body = lines.slice(0, -1).join("\n");
+          const data = JSON.parse(body);
+          resolve({ ok: statusCode >= 200 && statusCode < 300, status: statusCode, data });
+        } catch {
+          debugLog("api", "curl response parse failed");
+          resolve(null);
+        }
+      }
+    );
+    child.on("error", () => resolve(null));
+  });
 }
 async function fetchFromApi(token, tokenHash) {
   try {
@@ -214,22 +256,35 @@ async function fetchFromApi(token, tokenHash) {
         }
       }
     }
+    if (response.status === 403) {
+      debugLog("api", "403 from fetch, trying curl fallback");
+      const curlResult = await makeRequestViaCurl(token);
+      if (curlResult?.ok) {
+        return parseAndCacheLimits(curlResult.data, tokenHash);
+      }
+      debugLog("api", `curl fallback ${curlResult ? `returned ${curlResult.status}` : "failed"}`);
+      return null;
+    }
     if (!response.ok) {
       return null;
     }
     const data = await response.json();
-    const limits = {
-      five_hour: data.five_hour ?? null,
-      seven_day: data.seven_day ?? null,
-      seven_day_sonnet: data.seven_day_sonnet ?? null
-    };
-    usageCacheMap.set(tokenHash, { data: limits, timestamp: Date.now() });
-    await saveFileCache(tokenHash, limits);
-    return limits;
+    return parseAndCacheLimits(data, tokenHash);
   } catch (error) {
     debugLog("api", "Request failed", error);
     return null;
   }
+}
+async function parseAndCacheLimits(data, tokenHash) {
+  const d = data;
+  const limits = {
+    five_hour: d.five_hour ?? null,
+    seven_day: d.seven_day ?? null,
+    seven_day_sonnet: d.seven_day_sonnet ?? null
+  };
+  usageCacheMap.set(tokenHash, { data: limits, timestamp: Date.now() });
+  await saveFileCache(tokenHash, limits);
+  return limits;
 }
 async function loadFileCacheRaw(tokenHash, ttlSeconds) {
   try {

--- a/dist/index.js
+++ b/dist/index.js
@@ -409,6 +409,7 @@ function getSeparator() {
 
 // scripts/utils/api-client.ts
 import { readFile as readFile2, writeFile, mkdir, readdir, stat as stat2, unlink } from "fs/promises";
+import { execFile } from "child_process";
 import os from "os";
 import path from "path";
 
@@ -497,6 +498,7 @@ function debugLog(context, message, error) {
 }
 
 // scripts/utils/api-client.ts
+var API_URL = "https://api.anthropic.com/api/oauth/usage";
 var API_TIMEOUT_MS = 5e3;
 var MAX_RETRY_AFTER_MS = 1e4;
 var STALE_FALLBACK_SECONDS = 3600;
@@ -585,7 +587,7 @@ async function makeRequest(token) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
   try {
-    return await fetch("https://api.anthropic.com/api/oauth/usage", {
+    return await fetch(API_URL, {
       method: "GET",
       headers: {
         Accept: "application/json",
@@ -599,6 +601,46 @@ async function makeRequest(token) {
   } finally {
     clearTimeout(timeout);
   }
+}
+async function makeRequestViaCurl(token) {
+  return new Promise((resolve) => {
+    const child = execFile(
+      "curl",
+      [
+        "-s",
+        "-w",
+        "\n%{http_code}",
+        API_URL,
+        "-H",
+        "Accept: application/json",
+        "-H",
+        `User-Agent: claude-dashboard/${VERSION}`,
+        "-H",
+        `Authorization: Bearer ${token}`,
+        "-H",
+        "anthropic-beta: oauth-2025-04-20"
+      ],
+      { encoding: "utf-8", timeout: API_TIMEOUT_MS },
+      (error, stdout) => {
+        if (error) {
+          debugLog("api", "curl fallback failed", error);
+          resolve(null);
+          return;
+        }
+        try {
+          const lines = stdout.trimEnd().split("\n");
+          const statusCode = parseInt(lines[lines.length - 1], 10);
+          const body = lines.slice(0, -1).join("\n");
+          const data = JSON.parse(body);
+          resolve({ ok: statusCode >= 200 && statusCode < 300, status: statusCode, data });
+        } catch {
+          debugLog("api", "curl response parse failed");
+          resolve(null);
+        }
+      }
+    );
+    child.on("error", () => resolve(null));
+  });
 }
 async function fetchFromApi(token, tokenHash) {
   try {
@@ -618,22 +660,35 @@ async function fetchFromApi(token, tokenHash) {
         }
       }
     }
+    if (response.status === 403) {
+      debugLog("api", "403 from fetch, trying curl fallback");
+      const curlResult = await makeRequestViaCurl(token);
+      if (curlResult?.ok) {
+        return parseAndCacheLimits(curlResult.data, tokenHash);
+      }
+      debugLog("api", `curl fallback ${curlResult ? `returned ${curlResult.status}` : "failed"}`);
+      return null;
+    }
     if (!response.ok) {
       return null;
     }
     const data = await response.json();
-    const limits = {
-      five_hour: data.five_hour ?? null,
-      seven_day: data.seven_day ?? null,
-      seven_day_sonnet: data.seven_day_sonnet ?? null
-    };
-    usageCacheMap.set(tokenHash, { data: limits, timestamp: Date.now() });
-    await saveFileCache(tokenHash, limits);
-    return limits;
+    return parseAndCacheLimits(data, tokenHash);
   } catch (error) {
     debugLog("api", "Request failed", error);
     return null;
   }
+}
+async function parseAndCacheLimits(data, tokenHash) {
+  const d = data;
+  const limits = {
+    five_hour: d.five_hour ?? null,
+    seven_day: d.seven_day ?? null,
+    seven_day_sonnet: d.seven_day_sonnet ?? null
+  };
+  usageCacheMap.set(tokenHash, { data: limits, timestamp: Date.now() });
+  await saveFileCache(tokenHash, limits);
+  return limits;
 }
 async function loadFileCacheRaw(tokenHash, ttlSeconds) {
   try {
@@ -1139,10 +1194,10 @@ var rateLimit7dSonnetWidget = {
 import { basename, relative } from "path";
 
 // scripts/utils/git.ts
-import { execFile } from "child_process";
+import { execFile as execFile2 } from "child_process";
 function execGit(args, cwd, timeout) {
   return new Promise((resolve, reject) => {
-    execFile("git", ["--no-optional-locks", ...args], {
+    execFile2("git", ["--no-optional-locks", ...args], {
       cwd,
       encoding: "utf-8",
       timeout

--- a/scripts/utils/api-client.ts
+++ b/scripts/utils/api-client.ts
@@ -6,6 +6,7 @@
  * @handbook 7.1-common-api-pattern
  */
 import { readFile, writeFile, mkdir, readdir, stat, unlink } from 'fs/promises';
+import { execFile } from 'child_process';
 import os from 'os';
 import path from 'path';
 import { NEGATIVE_CACHE_SECONDS, type UsageLimits, type CacheEntry } from '../types.js';
@@ -14,6 +15,7 @@ import { hashToken } from './hash.js';
 import { VERSION } from '../version.js';
 import { debugLog } from './debug.js';
 
+const API_URL = 'https://api.anthropic.com/api/oauth/usage';
 const API_TIMEOUT_MS = 5000;
 const MAX_RETRY_AFTER_MS = 10000;
 const STALE_FALLBACK_SECONDS = 3600;
@@ -155,14 +157,14 @@ export async function fetchUsageLimits(ttlSeconds: number = 300): Promise<UsageL
 }
 
 /**
- * Make a single API request
+ * Make a single API request using Node.js fetch
  */
 async function makeRequest(token: string): Promise<Response> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
 
   try {
-    return await fetch('https://api.anthropic.com/api/oauth/usage', {
+    return await fetch(API_URL, {
       method: 'GET',
       headers: {
         Accept: 'application/json',
@@ -179,7 +181,55 @@ async function makeRequest(token: string): Promise<Response> {
 }
 
 /**
+ * Fallback API request using curl subprocess.
+ *
+ * Some environments (e.g. Node.js 20+ on Linux) get HTTP 403 from
+ * Anthropic's OAuth usage endpoint due to TLS fingerprint differences
+ * between Node's built-in HTTP client (undici) and standard clients
+ * like curl/wget/Python. This fallback uses curl as a subprocess to
+ * work around the issue.
+ */
+async function makeRequestViaCurl(token: string): Promise<{ ok: boolean; status: number; data: unknown } | null> {
+  return new Promise((resolve) => {
+    const child = execFile(
+      'curl',
+      [
+        '-s',
+        '-w', '\n%{http_code}',
+        API_URL,
+        '-H', 'Accept: application/json',
+        '-H', `User-Agent: claude-dashboard/${VERSION}`,
+        '-H', `Authorization: Bearer ${token}`,
+        '-H', 'anthropic-beta: oauth-2025-04-20',
+      ],
+      { encoding: 'utf-8', timeout: API_TIMEOUT_MS },
+      (error, stdout) => {
+        if (error) {
+          debugLog('api', 'curl fallback failed', error);
+          resolve(null);
+          return;
+        }
+        try {
+          const lines = stdout.trimEnd().split('\n');
+          const statusCode = parseInt(lines[lines.length - 1], 10);
+          const body = lines.slice(0, -1).join('\n');
+          const data = JSON.parse(body);
+          resolve({ ok: statusCode >= 200 && statusCode < 300, status: statusCode, data });
+        } catch {
+          debugLog('api', 'curl response parse failed');
+          resolve(null);
+        }
+      }
+    );
+
+    // Ensure child process is cleaned up on timeout
+    child.on('error', () => resolve(null));
+  });
+}
+
+/**
  * Internal function to fetch from API with single retry on 429
+ * and curl fallback on 403 (TLS fingerprint rejection)
  */
 async function fetchFromApi(token: string, tokenHash: string): Promise<UsageLimits | null> {
   try {
@@ -202,27 +252,44 @@ async function fetchFromApi(token: string, tokenHash: string): Promise<UsageLimi
       }
     }
 
+    // On 403, Node's TLS fingerprint may be rejected — fall back to curl
+    if (response.status === 403) {
+      debugLog('api', '403 from fetch, trying curl fallback');
+      const curlResult = await makeRequestViaCurl(token);
+      if (curlResult?.ok) {
+        return parseAndCacheLimits(curlResult.data, tokenHash);
+      }
+      debugLog('api', `curl fallback ${curlResult ? `returned ${curlResult.status}` : 'failed'}`);
+      return null;
+    }
+
     if (!response.ok) {
       return null;
     }
 
     const data = await response.json();
-
-    const limits: UsageLimits = {
-      five_hour: data.five_hour ?? null,
-      seven_day: data.seven_day ?? null,
-      seven_day_sonnet: data.seven_day_sonnet ?? null,
-    };
-
-    // Update caches
-    usageCacheMap.set(tokenHash, { data: limits, timestamp: Date.now() });
-    await saveFileCache(tokenHash, limits);
-
-    return limits;
+    return parseAndCacheLimits(data, tokenHash);
   } catch (error) {
     debugLog('api', 'Request failed', error);
     return null;
   }
+}
+
+/**
+ * Parse API response and update caches
+ */
+async function parseAndCacheLimits(data: unknown, tokenHash: string): Promise<UsageLimits> {
+  const d = data as Record<string, unknown>;
+  const limits: UsageLimits = {
+    five_hour: (d.five_hour as UsageLimits['five_hour']) ?? null,
+    seven_day: (d.seven_day as UsageLimits['seven_day']) ?? null,
+    seven_day_sonnet: (d.seven_day_sonnet as UsageLimits['seven_day_sonnet']) ?? null,
+  };
+
+  usageCacheMap.set(tokenHash, { data: limits, timestamp: Date.now() });
+  await saveFileCache(tokenHash, limits);
+
+  return limits;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Node.js's built-in fetch (undici) receives HTTP 403 "Request not allowed" from `https://api.anthropic.com/api/oauth/usage` on some environments (reproduced on Node.js 24.13.1 on Linux/WSL2). The same request succeeds with curl, wget, and Python urllib — pointing to TLS fingerprint-based rejection.
- This causes the `rateLimit5h` / `rateLimit7d` / `rateLimit7dSonnet` widgets to permanently show ⚠️ instead of actual usage data.
- This PR adds a `curl` subprocess fallback that activates **only** when `fetch` returns 403. The existing fetch path remains primary for environments where it works.

## Reproduction

```bash
# Node.js fetch gets 403
node -e "
const token = require('fs').readFileSync(require('os').homedir() + '/.claude/.credentials.json', 'utf-8');
const t = JSON.parse(token).claudeAiOauth.accessToken;
fetch('https://api.anthropic.com/api/oauth/usage', {
  headers: { Authorization: 'Bearer ' + t, 'anthropic-beta': 'oauth-2025-04-20' }
}).then(r => console.log('Status:', r.status));
"
# Status: 403

# curl succeeds with identical headers
curl -s -o /dev/null -w '%{http_code}' https://api.anthropic.com/api/oauth/usage \
  -H "Authorization: Bearer $(jq -r .claudeAiOauth.accessToken ~/.claude/.credentials.json)" \
  -H "anthropic-beta: oauth-2025-04-20"
# 200
```

## Changes

- `scripts/utils/api-client.ts`: Added `makeRequestViaCurl()` fallback using `execFile('curl', ...)` (not shell — secure)
- When `fetchFromApi()` gets a 403 from `makeRequest()`, it tries `makeRequestViaCurl()` before giving up
- Extracted `parseAndCacheLimits()` to share response parsing between fetch and curl paths
- No behavior change for environments where fetch works (curl fallback is never triggered)

## Test plan

- [x] `npm run build` succeeds
- [x] All 15 `api-client.test.ts` tests pass (3 pre-existing `linesChangedWidget` failures unrelated)
- [x] Manual test: status line shows `5h: 29% (2h13m)` instead of ⚠️ on Node.js 24 / Linux WSL2
- [ ] Verify no regression on macOS (fetch should succeed, curl fallback never triggered)

🤖 Generated with [Claude Code](https://claude.ai/code)