### PR TITLE
fix: use history.jsonl for lastPrompt widget

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // scripts/statusline.ts
-import { readFile as readFile8, stat as stat8 } from "fs/promises";
+import { readFile as readFile8, stat as stat9 } from "fs/promises";
 import { join as join6 } from "path";
 import { homedir as homedir6 } from "os";
 
@@ -1565,7 +1565,6 @@ var sessionDurationWidget = {
 // scripts/utils/transcript-parser.ts
 import { open as open2, stat as stat5 } from "fs/promises";
 import { basename as basename2 } from "path";
-import { homedir as homedir4 } from "os";
 var cachedTranscript = null;
 function parseJsonlContent(content) {
   const entries = [];
@@ -1771,38 +1770,6 @@ function extractTaskProgress(transcript) {
 }
 function extractTodoOrTaskProgress(transcript) {
   return extractTaskProgress(transcript) ?? extractTodoProgress(transcript);
-}
-async function getLastUserPrompt(sessionId) {
-  const historyPath = `${homedir4()}/.claude/history.jsonl`;
-  const CHUNK = 16 * 1024;
-  try {
-    const fileStat = await stat5(historyPath);
-    const size = Math.min(CHUNK, fileStat.size);
-    const fd = await open2(historyPath, "r");
-    try {
-      const buffer = Buffer.alloc(size);
-      await fd.read(buffer, 0, size, fileStat.size - size);
-      const lines = buffer.toString("utf-8").split("\n");
-      for (let i = lines.length - 1; i >= 0; i--) {
-        if (!lines[i])
-          continue;
-        try {
-          const entry = JSON.parse(lines[i]);
-          if (entry.sessionId === sessionId && entry.display?.trim() && entry.timestamp) {
-            return {
-              text: entry.display.replace(/\s+/g, " ").trim(),
-              timestamp: entry.timestamp
-            };
-          }
-        } catch {
-        }
-      }
-    } finally {
-      await fd.close();
-    }
-  } catch {
-  }
-  return null;
 }
 function extractAgentStatus(transcript) {
   const active = [];
@@ -3140,8 +3107,8 @@ var forecastWidget = {
 // scripts/utils/budget.ts
 import { readFile as readFile7, mkdir as mkdir4, writeFile as writeFile4 } from "fs/promises";
 import { join as join5 } from "path";
-import { homedir as homedir5 } from "os";
-var BUDGET_DIR = join5(homedir5(), ".cache", "claude-dashboard");
+import { homedir as homedir4 } from "os";
+var BUDGET_DIR = join5(homedir4(), ".cache", "claude-dashboard");
 var BUDGET_FILE = join5(BUDGET_DIR, "budget.json");
 var budgetCache = null;
 var dirEnsured = false;
@@ -3368,6 +3335,42 @@ var todayCostWidget = {
   }
 };
 
+// scripts/utils/history-parser.ts
+import { open as open3, stat as stat8 } from "fs/promises";
+import { homedir as homedir5 } from "os";
+async function getLastUserPrompt(sessionId) {
+  const historyPath = `${homedir5()}/.claude/history.jsonl`;
+  const CHUNK = 16 * 1024;
+  try {
+    const fileStat = await stat8(historyPath);
+    const size = Math.min(CHUNK, fileStat.size);
+    const fd = await open3(historyPath, "r");
+    try {
+      const buffer = Buffer.alloc(size);
+      await fd.read(buffer, 0, size, fileStat.size - size);
+      const lines = buffer.toString("utf-8").split("\n");
+      for (let i = lines.length - 1; i >= 0; i--) {
+        if (!lines[i])
+          continue;
+        try {
+          const entry = JSON.parse(lines[i]);
+          if (entry.sessionId === sessionId && entry.display?.trim() && entry.timestamp) {
+            return {
+              text: entry.display.replace(/\s+/g, " ").trim(),
+              timestamp: entry.timestamp
+            };
+          }
+        } catch {
+        }
+      }
+    } finally {
+      await fd.close();
+    }
+  } catch {
+  }
+  return null;
+}
+
 // scripts/widgets/last-prompt.ts
 var lastPromptWidget = {
   id: "lastPrompt",
@@ -3484,7 +3487,7 @@ async function readStdin() {
 }
 async function loadConfig() {
   try {
-    const fileStat = await stat8(CONFIG_PATH);
+    const fileStat = await stat9(CONFIG_PATH);
     const mtime = fileStat.mtimeMs;
     if (configCache?.mtime === mtime) {
       return configCache.config;

--- a/scripts/utils/history-parser.ts
+++ b/scripts/utils/history-parser.ts
@@ -1,0 +1,53 @@
+/**
+ * History parser - reads ~/.claude/history.jsonl for user prompt data
+ * Unlike transcript.jsonl, history.jsonl only contains actual user input
+ * via the `display` field, excluding skill/command expansions.
+ */
+
+import { open, stat } from 'fs/promises';
+import { homedir } from 'os';
+import type { LastPromptData } from '../types.js';
+
+/**
+ * Get the last user prompt from ~/.claude/history.jsonl.
+ * Tail-reads the last 16KB and reverse-scans for the current session's
+ * most recent entry.
+ */
+export async function getLastUserPrompt(
+  sessionId: string
+): Promise<LastPromptData | null> {
+  const historyPath = `${homedir()}/.claude/history.jsonl`;
+  const CHUNK = 16 * 1024;
+
+  try {
+    const fileStat = await stat(historyPath);
+    const size = Math.min(CHUNK, fileStat.size);
+    const fd = await open(historyPath, 'r');
+    try {
+      const buffer = Buffer.alloc(size);
+      await fd.read(buffer, 0, size, fileStat.size - size);
+      const lines = buffer.toString('utf-8').split('\n');
+
+      for (let i = lines.length - 1; i >= 0; i--) {
+        if (!lines[i]) continue;
+        try {
+          const entry = JSON.parse(lines[i]) as {
+            sessionId?: string;
+            display?: string;
+            timestamp?: string;
+          };
+          if (entry.sessionId === sessionId && entry.display?.trim() && entry.timestamp) {
+            return {
+              text: entry.display.replace(/\s+/g, ' ').trim(),
+              timestamp: entry.timestamp,
+            };
+          }
+        } catch { /* skip malformed lines */ }
+      }
+    } finally {
+      await fd.close();
+    }
+  } catch { /* file not found or read error */ }
+
+  return null;
+}

--- a/scripts/utils/transcript-parser.ts
+++ b/scripts/utils/transcript-parser.ts
@@ -6,8 +6,7 @@
 
 import { open, stat } from 'fs/promises';
 import { basename } from 'path';
-import { homedir } from 'os';
-import type { TranscriptEntry, ParsedTranscript, TodoProgressData, LastPromptData } from '../types.js';
+import type { TranscriptEntry, ParsedTranscript, TodoProgressData } from '../types.js';
 import { truncate } from './formatters.js';
 
 /**
@@ -327,51 +326,6 @@ export function extractTodoOrTaskProgress(
   transcript: ParsedTranscript
 ): TodoProgressData | null {
   return extractTaskProgress(transcript) ?? extractTodoProgress(transcript);
-}
-
-/**
- * Get the last user prompt from ~/.claude/history.jsonl.
- * Uses history.jsonl instead of transcript because transcript includes
- * skill/command expansions as user messages, while history.jsonl only
- * contains actual user input via the `display` field.
- */
-export async function getLastUserPrompt(
-  sessionId: string
-): Promise<LastPromptData | null> {
-  const historyPath = `${homedir()}/.claude/history.jsonl`;
-  const CHUNK = 16 * 1024;
-
-  try {
-    const fileStat = await stat(historyPath);
-    const size = Math.min(CHUNK, fileStat.size);
-    const fd = await open(historyPath, 'r');
-    try {
-      const buffer = Buffer.alloc(size);
-      await fd.read(buffer, 0, size, fileStat.size - size);
-      const lines = buffer.toString('utf-8').split('\n');
-
-      for (let i = lines.length - 1; i >= 0; i--) {
-        if (!lines[i]) continue;
-        try {
-          const entry = JSON.parse(lines[i]) as {
-            sessionId?: string;
-            display?: string;
-            timestamp?: string;
-          };
-          if (entry.sessionId === sessionId && entry.display?.trim() && entry.timestamp) {
-            return {
-              text: entry.display.replace(/\s+/g, ' ').trim(),
-              timestamp: entry.timestamp,
-            };
-          }
-        } catch { /* skip malformed lines */ }
-      }
-    } finally {
-      await fd.close();
-    }
-  } catch { /* file not found or read error */ }
-
-  return null;
 }
 
 /**

--- a/scripts/widgets/last-prompt.ts
+++ b/scripts/widgets/last-prompt.ts
@@ -8,7 +8,7 @@ import type { Widget } from './base.js';
 import type { WidgetContext, LastPromptData } from '../types.js';
 import { colorize, getTheme } from '../utils/colors.js';
 import { truncate } from '../utils/formatters.js';
-import { getLastUserPrompt } from '../utils/transcript-parser.js';
+import { getLastUserPrompt } from '../utils/history-parser.js';
 
 export const lastPromptWidget: Widget<LastPromptData> = {
   id: 'lastPrompt',


### PR DESCRIPTION
## Summary
- lastPrompt 위젯의 데이터 소스를 `transcript.jsonl` → `~/.claude/history.jsonl`로 변경
- transcript에는 스킬/커맨드 확장이 user 메시지로 포함되어 실제 프롬프트 대신 표시되는 문제 해결

## Changes
- `transcript-parser.ts`: `getLastUserPrompt()` — history.jsonl의 `display` 필드 + `sessionId` 매칭
- `last-prompt.ts`: transcript 의존 제거, `session_id`로 history 조회
- 파일 끝 16KB만 tail-read하여 역순 탐색

## Test plan
- [ ] `npm run build` passes
- [ ] 실제 세션에서 사용자 프롬프트 정상 표시
- [ ] 스킬/커맨드 실행 후에도 실제 프롬프트 유지