### PR TITLE
fix: resolve pasted text placeholders in lastPrompt widget

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3460,6 +3460,14 @@ import { open as open3, stat as stat9 } from "fs/promises";
 import { homedir as homedir5 } from "os";
 var HISTORY_PATH = `${homedir5()}/.claude/history.jsonl`;
 var CHUNK = 16 * 1024;
+function resolvePastedText(display, pastedContents) {
+  if (!pastedContents)
+    return display;
+  return display.replace(
+    /\[Pasted text #(\d+)[^\]]*\]/g,
+    (match, id) => pastedContents[id]?.content ?? match
+  );
+}
 var historyCache = null;
 async function getLastUserPrompt(sessionId) {
   try {
@@ -3484,8 +3492,9 @@ async function getLastUserPrompt(sessionId) {
         try {
           const entry = JSON.parse(lines[i]);
           if (entry.sessionId === sessionId && entry.display?.trim() && entry.timestamp) {
+            const text = resolvePastedText(entry.display, entry.pastedContents);
             const result = {
-              text: entry.display.replace(/\s+/g, " ").trim(),
+              text: text.replace(/\s+/g, " ").trim(),
               timestamp: entry.timestamp
             };
             historyCache.results.set(sessionId, result);

--- a/scripts/__tests__/history-parser.test.ts
+++ b/scripts/__tests__/history-parser.test.ts
@@ -84,6 +84,45 @@ describe('history-parser', () => {
       expect(result?.text).toBe('Valid');
     });
 
+    it('should resolve [Pasted text] placeholders from pastedContents', async () => {
+      await writeFile(HISTORY_FILE, JSON.stringify({
+        sessionId: 'sess-1',
+        display: '[Pasted text #1 +4 lines]',
+        pastedContents: { '1': { content: 'Line one\nLine two\nLine three\nLine four' } },
+        timestamp: '2024-01-01T10:00:00Z',
+      }));
+
+      const { getLastUserPrompt } = await import('../utils/history-parser.js');
+      const result = await getLastUserPrompt('sess-1');
+      expect(result?.text).toBe('Line one Line two Line three Line four');
+    });
+
+    it('should resolve pasted text mixed with typed text', async () => {
+      await writeFile(HISTORY_FILE, JSON.stringify({
+        sessionId: 'sess-1',
+        display: 'Here is [Pasted text #1 +2 lines] and some more text',
+        pastedContents: { '1': { content: 'pasted\ncontent' } },
+        timestamp: '2024-01-01T10:00:00Z',
+      }));
+
+      const { getLastUserPrompt } = await import('../utils/history-parser.js');
+      const result = await getLastUserPrompt('sess-1');
+      expect(result?.text).toBe('Here is pasted content and some more text');
+    });
+
+    it('should keep placeholder when pastedContents is missing', async () => {
+      await writeFile(HISTORY_FILE, JSON.stringify({
+        sessionId: 'sess-1',
+        display: '[Pasted text #1 +3 lines]',
+        pastedContents: {},
+        timestamp: '2024-01-01T10:00:00Z',
+      }));
+
+      const { getLastUserPrompt } = await import('../utils/history-parser.js');
+      const result = await getLastUserPrompt('sess-1');
+      expect(result?.text).toBe('[Pasted text #1 +3 lines]');
+    });
+
     it('should use cached result when file size unchanged', async () => {
       await writeFile(HISTORY_FILE, JSON.stringify({
         sessionId: 'sess-1', display: 'Cached prompt', timestamp: '2024-01-01T10:00:00Z',

--- a/scripts/utils/git.ts
+++ b/scripts/utils/git.ts
@@ -1,6 +1,7 @@
 /**
  * Git utilities - shared async git command execution
  * @handbook 3.3-widget-data-sources
+ * @tested scripts/__tests__/widgets.test.ts (countUntrackedLines via mock)
  */
 
 import { execFile } from 'child_process';

--- a/scripts/utils/history-parser.ts
+++ b/scripts/utils/history-parser.ts
@@ -15,8 +15,20 @@ const HISTORY_PATH = `${homedir()}/.claude/history.jsonl`;
 const CHUNK = 16 * 1024;
 
 /**
- * Cached last prompt per session, invalidated by file size change.
+ * Replace [Pasted text #N ...] placeholders in display with actual content
+ * from pastedContents. Falls back to original display if content unavailable.
  */
+function resolvePastedText(
+  display: string,
+  pastedContents?: Record<string, { content?: string }>
+): string {
+  if (!pastedContents) return display;
+  return display.replace(
+    /\[Pasted text #(\d+)[^\]]*\]/g,
+    (match, id: string) => pastedContents[id]?.content ?? match
+  );
+}
+
 let historyCache: {
   fileSize: number;
   /** Cached results keyed by sessionId */
@@ -58,11 +70,13 @@ export async function getLastUserPrompt(
           const entry = JSON.parse(lines[i]) as {
             sessionId?: string;
             display?: string;
+            pastedContents?: Record<string, { content?: string }>;
             timestamp?: string;
           };
           if (entry.sessionId === sessionId && entry.display?.trim() && entry.timestamp) {
+            const text = resolvePastedText(entry.display, entry.pastedContents);
             const result: LastPromptData = {
-              text: entry.display.replace(/\s+/g, ' ').trim(),
+              text: text.replace(/\s+/g, ' ').trim(),
               timestamp: entry.timestamp,
             };
             historyCache.results.set(sessionId, result);

--- a/scripts/utils/history-parser.ts
+++ b/scripts/utils/history-parser.ts
@@ -4,6 +4,7 @@
  * via the `display` field, excluding skill/command expansions.
  *
  * Uses size-based caching: only re-reads when file has grown.
+ * @handbook 3.3-widget-data-sources
  * @tested scripts/__tests__/history-parser.test.ts
  */
 


### PR DESCRIPTION
## Summary
- lastPrompt 위젯에서 멀티라인 붙여넣기 시 `[Pasted text #1 +4 lines]` 플레이스홀더가 그대로 표시되던 버그 수정
- `history.jsonl`의 `pastedContents` 객체에서 실제 텍스트를 읽어 치환하도록 `resolvePastedText()` 함수 추가

## Test plan
- [ ] 멀티라인 텍스트 붙여넣기 후 lastPrompt에 실제 내용 표시 확인
- [ ] 일반 한 줄 입력 시 기존 동작 유지 확인
- [ ] pastedContents 없는 기존 히스토리 항목 정상 표시 확인