### PR TITLE
fix: resolve fork PR workflow failures

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,8 +6,8 @@ on:
 
 jobs:
   claude-review:
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
-    environment: ${{ github.event.pull_request.head.repo.fork && 'fork-pr-review' || '' }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,13 +1,11 @@
 name: Release Notes Drafter
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches: [main]
 
 jobs:
   draft-release-notes:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -15,24 +13,34 @@ jobs:
       id-token: write
 
     steps:
+      - name: Find merged PR
+        id: find-pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER=$(gh api repos/${{ github.repository }}/commits/${{ github.sha }}/pulls --jq '.[0].number // empty' 2>/dev/null || true)
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
       - name: Checkout repository
+        if: steps.find-pr.outputs.pr_number != ''
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Draft Release Notes
+        if: steps.find-pr.outputs.pr_number != ''
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            PR #${{ github.event.pull_request.number }} has been merged.
+            PR #${{ steps.find-pr.outputs.pr_number }} has been merged.
 
             Your task: analyze this merged PR and append its release notes to an existing draft GitHub release.
 
             ## Steps
 
-            1. Run `gh pr view ${{ github.event.pull_request.number }} --json title,body,files` to understand the PR.
-            2. Run `gh pr diff ${{ github.event.pull_request.number }}` to see the actual code changes.
+            1. Run `gh pr view ${{ steps.find-pr.outputs.pr_number }} --json title,body,files` to understand the PR.
+            2. Run `gh pr diff ${{ steps.find-pr.outputs.pr_number }}` to see the actual code changes.
             3. Check for an existing draft release: `gh release list --json tagName,isDraft,name | head -5`
             4. Write a concise release note entry in English for this PR:
                - One line summary with PR reference (e.g., "- Add budget tracking widget (#42)")


### PR DESCRIPTION
## Summary
- Fork PR에서 Claude Code Review 워크플로우 OIDC 토큰 발급 실패 해결
- Release Notes Drafter가 fork PR 머지 시에도 정상 동작하도록 트리거 변경

## Changes
### claude-code-review.yml
- Fork PR에서 스킵 (`if: !github.event.pull_request.head.repo.fork`)
- `fork-pr-review` environment 분기 제거

### release-drafter.yml
- `pull_request: closed` → `push: main` 트리거로 변경
- 커밋에서 PR 번호를 GitHub API로 추출
- PR 없는 직접 push는 자동 스킵

## Context
Fork PR (#60) 머지 시 두 워크플로우 모두 `ACTIONS_ID_TOKEN_REQUEST_URL` 환경변수가 주입되지 않아 OIDC 토큰 발급 실패. GitHub가 fork 출처 PR에 대해 OIDC를 차단하는 보안 정책 때문.

## Test plan
- [ ] Non-fork PR 머지 시 release-drafter 정상 동작 확인
- [ ] Fork PR 시 claude-code-review 스킵 확인
- [ ] 직접 push (PR 없는 커밋) 시 release-drafter 스킵 확인