### PR TITLE
feat: include vimMode, apiDuration, tagStatus in detailed preset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,7 +184,7 @@ const DISPLAY_PRESETS = {
     ['configCounts', 'toolActivity', 'agentStatus', 'cacheHit', 'performance'],
     ['tokenBreakdown', 'forecast', 'budget', 'todayCost'],
     ['codexUsage', 'geminiUsage', 'linesChanged', 'outputStyle', 'version', 'peakHours'],
-    ['lastPrompt'],
+    ['lastPrompt', 'vimMode', 'apiDuration', 'tagStatus'],
   ],
 };
 ```

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ i18n: English and Korean supported (auto-detect or set via setup).
 |------|-------|---------|
 | `compact` | 1 | model, context, cost, rateLimit5h/7d/7dSonnet, zaiUsage |
 | `normal` | 2 | + projectInfo, sessionId, sessionDuration, burnRate, todoProgress |
-| `detailed` | 6 | + depletionTime, configCounts, toolActivity, agentStatus, cacheHit, performance, tokenBreakdown, forecast, budget, codexUsage, geminiUsage, linesChanged, outputStyle, version, peakHours, lastPrompt |
+| `detailed` | 6 | + depletionTime, configCounts, toolActivity, agentStatus, cacheHit, performance, tokenBreakdown, forecast, budget, codexUsage, geminiUsage, linesChanged, outputStyle, version, peakHours, lastPrompt, vimMode, apiDuration, tagStatus |
 
 **Configuration file** (`~/.claude/claude-dashboard.local.json`):
 

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -18,7 +18,7 @@ Configure the claude-dashboard status line plugin with widget system support.
 - `$1`: Display mode
   - `compact` (default): 1 line (model, context, cost, rateLimit5h, rateLimit7d, rateLimit7dSonnet, zaiUsage)
   - `normal`: 2 lines (+ projectInfo, sessionId, sessionDuration, burnRate, todoProgress)
-  - `detailed`: 6 lines (+ sessionName, tokenSpeed, depletionTime, configCounts, toolActivity, agentStatus, cacheHit, performance, tokenBreakdown, forecast, budget, todayCost, codexUsage, geminiUsage, linesChanged, outputStyle, version, peakHours, lastPrompt)
+  - `detailed`: 6 lines (+ sessionName, tokenSpeed, depletionTime, configCounts, toolActivity, agentStatus, cacheHit, performance, tokenBreakdown, forecast, budget, todayCost, codexUsage, geminiUsage, linesChanged, outputStyle, version, peakHours, lastPrompt, vimMode, apiDuration, tagStatus)
   - `custom`: Custom widget configuration (requires `$4`)
 
 - `$2`: Language preference

--- a/dist/index.js
+++ b/dist/index.js
@@ -20,7 +20,7 @@ var DISPLAY_PRESETS = {
     ["configCounts", "toolActivity", "agentStatus", "cacheHit", "performance"],
     ["tokenBreakdown", "forecast", "budget", "todayCost"],
     ["codexUsage", "geminiUsage", "linesChanged", "outputStyle", "version", "peakHours"],
-    ["lastPrompt"]
+    ["lastPrompt", "vimMode", "apiDuration", "tagStatus"]
   ]
 };
 var PRESET_CHAR_MAP = {

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -167,7 +167,7 @@ export const DISPLAY_PRESETS: Record<Exclude<DisplayMode, 'custom'>, WidgetId[][
     ['configCounts', 'toolActivity', 'agentStatus', 'cacheHit', 'performance'],
     ['tokenBreakdown', 'forecast', 'budget', 'todayCost'],
     ['codexUsage', 'geminiUsage', 'linesChanged', 'outputStyle', 'version', 'peakHours'],
-    ['lastPrompt'],
+    ['lastPrompt', 'vimMode', 'apiDuration', 'tagStatus'],
   ],
 };
 

--- a/website/src/content/docs/getting-started/quick-start.md
+++ b/website/src/content/docs/getting-started/quick-start.md
@@ -57,7 +57,8 @@ Shows all available widgets including analytics, multi-CLI usage, and insights.
 📁 project (main ↑3) │ » feature-auth │ 🔑 abc123 │ ⏱ 45m │ 🔥 5K/m │ ⚡ 67 tok/s │ ⏳ 2h │ ✓ 3/5
 CLAUDE.md: 2 │ ⚙️ Read(app.ts) (12 done) │ 🤖 Agent: 1 │ 📦 85% │ 🟢 72%
 📊 In 30K · Out 8K │ 📈 ~$8/h │ 💵 $5/$15 │ 💰 Today: $4.83
-🔷 codex │ 💎 gemini │ +156 -23 │ concise │ v1.0.80
+🔷 codex │ 💎 gemini │ +156 -23 │ concise │ v1.0.80 │ Off-Peak (23h9m)
+💬 14:32 Fix the authentication bug │ NORMAL │ API 42% │ 🏷 v1.2.3 +5
 ```
 
 ## Specify Language and Plan

--- a/website/src/content/docs/guides/display-modes.md
+++ b/website/src/content/docs/guides/display-modes.md
@@ -48,7 +48,7 @@ Shows all available widgets across six lines, including analytics, tool activity
 **Line 3:** configCounts, toolActivity, agentStatus, cacheHit, performance<br/>
 **Line 4:** tokenBreakdown, forecast, budget, todayCost<br/>
 **Line 5:** codexUsage, geminiUsage, linesChanged, outputStyle, version, peakHours<br/>
-**Line 6:** lastPrompt
+**Line 6:** lastPrompt, vimMode, apiDuration, tagStatus
 
 ```
 ◆ Opus(X) │ ██░░ 80% │ $1.25 │ 5h: 42% │ 7d: 69%
@@ -56,7 +56,7 @@ Shows all available widgets across six lines, including analytics, tool activity
 CLAUDE.md: 2 │ ⚙️ Read(app.ts) (12 done) │ 🤖 Agent: 1 │ 📦 85% │ 🟢 72%
 📊 In 30K · Out 8K │ 📈 ~$8/h │ 💵 $5/$15 │ 💰 Today: $4.83
 🔷 codex │ 💎 gemini │ +156 -23 │ concise │ v1.0.80 │ Off-Peak (23h9m)
-💬 14:32 Fix the authentication bug in middleware
+💬 14:32 Fix the authentication bug in middleware │ NORMAL │ API 42% │ 🏷 v1.2.3 +5
 ```
 
 ```

--- a/website/src/content/docs/ko/getting-started/quick-start.md
+++ b/website/src/content/docs/ko/getting-started/quick-start.md
@@ -57,7 +57,8 @@ sidebar:
 📁 project (main ↑3) │ » feature-auth │ 🔑 abc123 │ ⏱ 45m │ 🔥 5K/m │ ⚡ 67 tok/s │ ⏳ 2h │ ✓ 3/5
 CLAUDE.md: 2 │ ⚙️ Read(app.ts) (12 done) │ 🤖 Agent: 1 │ 📦 85% │ 🟢 72%
 📊 In 30K · Out 8K │ 📈 ~$8/h │ 💵 $5/$15 │ 💰 오늘: $4.83
-🔷 codex │ 💎 gemini │ +156 -23 │ concise │ v1.0.80
+🔷 codex │ 💎 gemini │ +156 -23 │ concise │ v1.0.80 │ 비피크 (23h9m)
+💬 14:32 미들웨어 인증 버그 수정해줘 │ NORMAL │ API 42% │ 🏷 v1.2.3 +5
 ```
 
 ## 언어 및 플랜 설정

--- a/website/src/content/docs/ko/guides/display-modes.md
+++ b/website/src/content/docs/ko/guides/display-modes.md
@@ -54,7 +54,7 @@ Compact의 모든 위젯에 프로젝트 정보와 세션 관련 위젯을 추�
 **3줄:** configCounts, toolActivity, agentStatus, cacheHit, performance<br/>
 **4줄:** tokenBreakdown, forecast, budget, todayCost<br/>
 **5줄:** codexUsage, geminiUsage, linesChanged, outputStyle, version, peakHours<br/>
-**6줄:** lastPrompt
+**6줄:** lastPrompt, vimMode, apiDuration, tagStatus
 
 ```
 ◆ Opus(X) │ ██░░ 80% │ $1.25 │ 5h: 42% │ 7d: 69%
@@ -62,7 +62,7 @@ Compact의 모든 위젯에 프로젝트 정보와 세션 관련 위젯을 추�
 CLAUDE.md: 2 │ ⚙️ Read(app.ts) (12 done) │ 🤖 Agent: 1 │ 📦 85% │ 🟢 72%
 📊 In 30K · Out 8K │ 📈 ~$8/h │ 💵 $5/$15 │ 💰 오늘: $4.83
 🔷 codex │ 💎 gemini │ +156 -23 │ concise │ v1.0.80 │ 비피크 (23h9m)
-💬 14:32 미들웨어 인증 버그 수정해줘
+💬 14:32 미들웨어 인증 버그 수정해줘 │ NORMAL │ API 42% │ 🏷 v1.2.3 +5
 ```
 
 ## Custom (사용자 정의)


### PR DESCRIPTION
## Summary
- Added `vimMode`, `apiDuration`, `tagStatus` to the last line of the `detailed` display preset so users who pick that mode see the full widget set by default.
- All three widgets are conditional (auto-hide when not applicable), so this is purely additive — nothing is forced onto users who have them disabled.
- Specifically fixes a pre-existing drift where `tagStatus` (added in #65) was never registered in the `detailed` preset.

## Changes
- `scripts/types.ts` — `DISPLAY_PRESETS.detailed` line 6 extended.
- `dist/index.js` — rebuilt.
- Docs synced: `README.md`, `CLAUDE.md`, `commands/setup.md`, `website/guides/display-modes.md` (en/ko), `website/getting-started/quick-start.md` (en/ko).
- Visual examples in display-modes and quick-start now render the full 6-line layout, including a Line 5 `peakHours` label that was also missing.

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (433 tests)
- [x] `detailed` preset renders 6 lines; conditional widgets (`vimMode`, `tagStatus`) auto-hide when not applicable
- [x] `apiDuration` shows only when session has API time accumulated