### PR TITLE
fix(setup): group catppuccin variants to fit AskUserQuestion 4-option limit

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -111,8 +111,10 @@ Use AskUserQuestion to ask the user. Batch independent questions into a single A
      ```
 2. Language: auto (recommended), en, ko
 3. Plan: max (recommended), pro
-4. Theme: default (recommended), minimal, catppuccin, catppuccinLatte, "dracula / gruvbox / nord / tokyoNight / solarized"
+4. Theme: default (recommended), minimal, "catppuccin (mocha / latte — light)", "dracula / gruvbox / nord / tokyoNight / solarized"
+   - All themes are dark except `catppuccinLatte`, which is designed for light-mode terminals
    - If multi-option selected: ask in next turn which one
+   - For catppuccin, map `mocha` → config value `catppuccin`, `latte` → `catppuccinLatte`
 
 **Turn 2** — If display mode = "custom", ask for each line's widgets:
 - Show available widgets table for reference


### PR DESCRIPTION
## Summary

- The Theme question in `/claude-dashboard:setup` listed 5 options (`default`, `minimal`, `catppuccin`, `catppuccinLatte`, dark-theme group), but `AskUserQuestion` enforces a maximum of 4 options per question (`maxItems: 4`).
- Because of the limit, Claude had to drop one option to fit, and `catppuccinLatte` was inconsistently omitted since it overlapped semantically with `catppuccin`.
- Group the two catppuccin variants into a single expandable option (`"catppuccin (mocha / latte — light)"`), matching the existing 2-turn pattern used by the dracula/gruvbox/... group. Brings the option count down to 4 so the limit is respected.
- Preserve backward compatibility by mapping `mocha` → existing config value `catppuccin`. Call out that `latte` is the light variant so users on light-mode terminals aren't confused when picking a theme.

## Test plan

- [x] Theme question in interactive mode shows 4 options (within `AskUserQuestion` limit)
- [x] Selecting `catppuccin` triggers a Turn 2 follow-up asking for `mocha` / `latte`
- [x] Selecting `latte` writes `"theme": "catppuccinLatte"` to the config
- [x] Selecting `mocha` writes `"theme": "catppuccin"` to `~/.claude/claude-dashboard.local.json` (backward compatibility)
- [x] Verify `catppuccinLatte` readability on a light-mode terminal