### PR TITLE
docs: rewrite custom-mode setup flow + drop jq dependency

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -229,14 +229,14 @@ Preset characters: `M`=model, `C`=context, `b`=contextBar, `%`=contextPercentage
 
 Add or update the statusLine configuration in `~/.claude/settings.json`:
 
-**Find the plugin path and update settings.json** (copy-paste one-liner). Uses an inline Node.js script — Node is always available because the plugin itself runs on Node, so no extra dependency (like `jq`) is required:
+**Find the plugin path and update settings.json** (copy-paste one-liner):
 ```bash
 SLPATH="$(ls -d ~/.claude/plugins/cache/claude-dashboard/claude-dashboard/*/dist/index.js 2>/dev/null | sort -V | tail -1)" node -e 'const fs=require("fs"),os=require("os"),p=os.homedir()+"/.claude/settings.json";const s=fs.existsSync(p)?JSON.parse(fs.readFileSync(p,"utf8")):{};s.statusLine={type:"command",command:"node "+process.env.SLPATH};fs.writeFileSync(p,JSON.stringify(s,null,2));'
 ```
 
 This command:
 1. Finds the latest plugin version dynamically
-2. Updates `statusLine` in settings.json with the correct path, preserving every other key
+2. Updates `statusLine` in settings.json with the correct path
 
 **IMPORTANT**: After updating the plugin via `/plugin update claude-dashboard`, run `/claude-dashboard:update` to update the statusLine path to the latest version.
 

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -116,12 +116,37 @@ Use AskUserQuestion to ask the user. Batch independent questions into a single A
    - If multi-option selected: ask in next turn which one
    - For catppuccin, map `mocha` → config value `catppuccin`, `latte` → `catppuccinLatte`
 
-**Turn 2** — If display mode = "custom", ask for each line's widgets:
-- Show available widgets table for reference
-- Line 1 widgets (comma-separated text input with suggested combinations)
-- Ask if they want to add Line 2
-- If yes, Line 2 widgets
-- Continue until they say no (no line limit)
+**Turn 2** — If display mode = "custom", build the layout one line at a time using category-based multi-select.
+
+For each line `N` (starting at 1), repeat the following sub-flow until the user declines to add another line:
+
+**Step A — Pick categories for line `N`:**
+Single AskUserQuestion call with `multiSelect: true`, max 4 options. Ask: "Line `N`: which widget categories do you want to pull from?" The 4 category options are:
+
+1. **Model & Context** — `model`, `context`, `contextBar`, `contextPercentage`, `contextUsage`
+2. **Cost & Limits** — `cost`, `rateLimit5h`, `rateLimit7d`, `rateLimit7dSonnet`, `budget`, `forecast`, `todayCost`
+3. **Project, Session & Activity** — `projectInfo`, `sessionId`, `sessionIdFull`, `sessionDuration`, `sessionName`, `configCounts`, `toolActivity`, `agentStatus`, `todoProgress`, `outputStyle`, `vimMode`, `linesChanged`, `version`, `lastPrompt`
+4. **Performance, Tokens & Other CLIs** — `burnRate`, `tokenSpeed`, `cacheHit`, `performance`, `tokenBreakdown`, `depletionTime`, `apiDuration`, `peakHours`, `tagStatus`, `codexUsage`, `geminiUsage`, `geminiUsageAll`, `zaiUsage`
+
+**Step B — Pick widgets from each selected category:**
+For every category the user selected in Step A, send one AskUserQuestion call with `multiSelect: true` listing the widgets in that category. AskUserQuestion allows max 4 options per call, so if a category has more than 4 widgets, split into multiple consecutive calls (e.g. "Cost & Limits (1/2)", "Cost & Limits (2/2)") — the user can pick zero or more widgets from each page.
+
+Each widget option's `description` should be a short version of the table at the top of this file (e.g. `cost` → "Session cost in USD").
+
+Collect every selected widget into an ordered list for line `N`, preserving the order they were chosen.
+
+**Step C — Add another line?**
+Single AskUserQuestion call (not multi-select) asking: "Line `N` has `[widget1, widget2, ...]`. Add another line?" with options `No (finish)` and `Yes, add Line N+1`. If the user picks "No", end the loop. If "Yes", increment `N` and return to Step A. There is no hard line limit.
+
+**Notes for the assistant running this flow:**
+- If the user selects zero widgets for a line (no categories or no widgets within selected categories), warn them and re-ask Step A for that same line — empty lines are not allowed.
+- Show the running layout in Step C's question text so the user always sees what they've built so far.
+- Keep the multi-select widget questions free of preset/combination options — the whole point of custom mode is per-widget control.
+- **Track already-placed widgets across lines.** Maintain a `placed` set of every widget chosen so far. Starting from line 2 onward:
+  - In Step A, list each category's `description` using **only the widgets not yet in `placed`** (e.g. if `model` and `context` are already placed, the Model & Context description becomes "contextBar, contextPercentage, contextUsage"). Truncate with "etc." past ~6–8 names if needed.
+  - If a category has zero remaining widgets, **omit the entire category option** from Step A's choices.
+  - In Step B, exclude already-placed widgets from each category's multi-select options as well.
+  - If every category becomes empty (all widgets placed), inform the user and end the loop after the current line — there is nothing left to add.
 
 **Turn 3** — Ask: "Do you want to hide any widgets?"
 - Options: No (recommended), Yes

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -1,7 +1,7 @@
 ---
 description: Configure claude-dashboard status line settings
 argument-hint: "[displayMode] [language] [plan] | custom \"widgets\""
-allowed-tools: Read, Write, Bash(jq:*), Bash(cat:*), Bash(mkdir:*), AskUserQuestion
+allowed-tools: Read, Write, Bash(node:*), Bash(cat:*), Bash(mkdir:*), Bash(ls:*), Bash(sort:*), Bash(tail:*), AskUserQuestion
 ---
 
 # Claude Dashboard Setup
@@ -229,14 +229,14 @@ Preset characters: `M`=model, `C`=context, `b`=contextBar, `%`=contextPercentage
 
 Add or update the statusLine configuration in `~/.claude/settings.json`:
 
-**Find the plugin path and update settings.json** (copy-paste one-liner):
+**Find the plugin path and update settings.json** (copy-paste one-liner). Uses an inline Node.js script — Node is always available because the plugin itself runs on Node, so no extra dependency (like `jq`) is required:
 ```bash
-jq --arg path "$(ls -d ~/.claude/plugins/cache/claude-dashboard/claude-dashboard/*/dist/index.js 2>/dev/null | sort -V | tail -1)" '.statusLine = {"type": "command", "command": ("node " + $path)}' ~/.claude/settings.json > ~/.claude/settings.json.tmp && mv ~/.claude/settings.json.tmp ~/.claude/settings.json
+SLPATH="$(ls -d ~/.claude/plugins/cache/claude-dashboard/claude-dashboard/*/dist/index.js 2>/dev/null | sort -V | tail -1)" node -e 'const fs=require("fs"),os=require("os"),p=os.homedir()+"/.claude/settings.json";const s=fs.existsSync(p)?JSON.parse(fs.readFileSync(p,"utf8")):{};s.statusLine={type:"command",command:"node "+process.env.SLPATH};fs.writeFileSync(p,JSON.stringify(s,null,2));'
 ```
 
 This command:
 1. Finds the latest plugin version dynamically
-2. Updates `statusLine` in settings.json with the correct path
+2. Updates `statusLine` in settings.json with the correct path, preserving every other key
 
 **IMPORTANT**: After updating the plugin via `/plugin update claude-dashboard`, run `/claude-dashboard:update` to update the statusLine path to the latest version.
 

--- a/commands/update.md
+++ b/commands/update.md
@@ -16,7 +16,7 @@ Run this command after updating the plugin via `/plugin update claude-dashboard`
 ls -d ~/.claude/plugins/cache/claude-dashboard/claude-dashboard/*/ 2>/dev/null | grep -E '/[0-9]+\.[0-9]+\.[0-9]+/$' | sort -V | tail -1
 ```
 
-2. Update settings.json with the latest version path. Uses an inline Node.js script — Node is always available because the plugin itself runs on Node, so no extra dependency (like `jq`) is required:
+2. Update settings.json with the latest version path:
 ```bash
 LATEST_VERSION=$(ls -d ~/.claude/plugins/cache/claude-dashboard/claude-dashboard/*/ 2>/dev/null | grep -E '/[0-9]+\.[0-9]+\.[0-9]+/$' | sort -V | tail -1 | xargs basename)
 NEWCMD="node ~/.claude/plugins/cache/claude-dashboard/claude-dashboard/${LATEST_VERSION}/dist/index.js" node -e 'const fs=require("fs"),os=require("os"),p=os.homedir()+"/.claude/settings.json";const s=JSON.parse(fs.readFileSync(p,"utf8"));s.statusLine=s.statusLine||{type:"command"};s.statusLine.command=process.env.NEWCMD;fs.writeFileSync(p,JSON.stringify(s,null,2));'

--- a/commands/update.md
+++ b/commands/update.md
@@ -1,6 +1,6 @@
 ---
 description: Update statusLine path to latest plugin version
-allowed-tools: Read, Bash(jq:*), Bash(ls:*), Bash(sort:*), Bash(tail:*), Bash(mv:*)
+allowed-tools: Read, Bash(node:*), Bash(ls:*), Bash(grep:*), Bash(sort:*), Bash(tail:*), Bash(xargs:*), Bash(basename:*)
 ---
 
 # Claude Dashboard Update
@@ -16,10 +16,10 @@ Run this command after updating the plugin via `/plugin update claude-dashboard`
 ls -d ~/.claude/plugins/cache/claude-dashboard/claude-dashboard/*/ 2>/dev/null | grep -E '/[0-9]+\.[0-9]+\.[0-9]+/$' | sort -V | tail -1
 ```
 
-2. Update settings.json with the latest version path:
+2. Update settings.json with the latest version path. Uses an inline Node.js script — Node is always available because the plugin itself runs on Node, so no extra dependency (like `jq`) is required:
 ```bash
 LATEST_VERSION=$(ls -d ~/.claude/plugins/cache/claude-dashboard/claude-dashboard/*/ 2>/dev/null | grep -E '/[0-9]+\.[0-9]+\.[0-9]+/$' | sort -V | tail -1 | xargs basename)
-jq --arg path "node ~/.claude/plugins/cache/claude-dashboard/claude-dashboard/${LATEST_VERSION}/dist/index.js" '.statusLine.command = $path' ~/.claude/settings.json > ~/.claude/settings.json.tmp && mv ~/.claude/settings.json.tmp ~/.claude/settings.json
+NEWCMD="node ~/.claude/plugins/cache/claude-dashboard/claude-dashboard/${LATEST_VERSION}/dist/index.js" node -e 'const fs=require("fs"),os=require("os"),p=os.homedir()+"/.claude/settings.json";const s=JSON.parse(fs.readFileSync(p,"utf8"));s.statusLine=s.statusLine||{type:"command"};s.statusLine.command=process.env.NEWCMD;fs.writeFileSync(p,JSON.stringify(s,null,2));'
 ```
 
 3. Show the user what was updated:


### PR DESCRIPTION
## Summary

- Rewrite Turn 2 of `/claude-dashboard:setup` interactive flow for `custom` display mode. The previous step asked the user to type a comma-separated widget list; the new flow is a per-line category-based `AskUserQuestion` loop with `multiSelect: true`. Widgets already placed on earlier lines are excluded from later prompts so they cannot be repeated.
- Replace the `jq` dependency in both `/claude-dashboard:setup` and `/claude-dashboard:update` with a small inline Node.js script. Node.js is always available because the plugin itself runs on it, so no `command -v` fallback is needed — this fixes installation on systems where `jq` is not installed (notably stock macOS and Windows). Existing `settings.json` keys are preserved.

## Test plan

- [ ] Run `/claude-dashboard:setup` interactively, pick `custom` mode, and confirm the category → widget multi-select flow renders correctly and excludes already-placed widgets on later lines.
- [ ] Run the setup one-liner on a machine **without** `jq` installed and verify `~/.claude/settings.json` is updated correctly while preserving other keys.
- [ ] Run `/claude-dashboard:update` after a `/plugin update claude-dashboard` and verify the `statusLine.command` points to the newest cached version.
- [ ] Verify the resulting status line still renders normally after both commands.