### PR TITLE
chore: bump actions/checkout from v4 to v6

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
3 workflow의 `actions/checkout`을 v4 → v6 으로 일괄 갱신.

## Changes
- `.github/workflows/claude.yml`
- `.github/workflows/claude-code-review.yml`
- `.github/workflows/release-drafter.yml`

## Compatibility
- 최신 v6.0.2 (2026-01) 기준 — 주요 변경: Node.js 24 기본, credentials를 별도 파일에 persist.
- 모든 워크플로가 `ubuntu-latest` runner라 Node 24 지원. 호환 영향 없음.
- workflow의 `with:` 옵션(`fetch-depth`) 등은 그대로 호환.

## Test plan
- [ ] (자동) 다음 PR에서 claude-code-review workflow 정상 트리거 확인
- [ ] (자동) merge 시 release-drafter workflow 정상 트리거 확인