### PR TITLE
feat: centralize emoji icons with VS-16 variation selectors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,8 @@ claude-dashboard/
 | API 클라이언트 | `scripts/utils/api-client.ts` |
 | Cross-process file cache | `scripts/utils/file-cache.ts` |
 | 포매팅 유틸리티 | `scripts/utils/formatters.ts` |
+| 이모지 아이콘 (단일 출처) | `scripts/utils/emoji.ts` |
+| Registry invariant 테스트 | `scripts/__tests__/emoji.test.ts` |
 
 ## Widget Architecture
 

--- a/dist/check-usage.js
+++ b/dist/check-usage.js
@@ -1618,6 +1618,36 @@ function colorize(text, color) {
   return `${color}${text}${RESET}`;
 }
 
+// scripts/utils/emoji.ts
+var ICON = {
+  warning: "\u26A0\uFE0F",
+  gear: "\u2699\uFE0F",
+  alarm: "\u{1F6A8}\uFE0F",
+  stopwatch: "\u23F1\uFE0F",
+  hourglass: "\u23F3\uFE0F",
+  zap: "\u26A1\uFE0F",
+  banknote: "\u{1F4B5}\uFE0F",
+  moneyBag: "\u{1F4B0}\uFE0F",
+  chartUp: "\u{1F4C8}\uFE0F",
+  robot: "\u{1F916}\uFE0F",
+  person: "\u{1F464}\uFE0F",
+  folder: "\u{1F4C1}\uFE0F",
+  tree: "\u{1F333}\uFE0F",
+  label: "\u{1F3F7}\uFE0F",
+  package: "\u{1F4E6}\uFE0F",
+  chart: "\u{1F4CA}\uFE0F",
+  blueDiamond: "\u{1F537}\uFE0F",
+  gem: "\u{1F48E}\uFE0F",
+  orangeCircle: "\u{1F7E0}\uFE0F",
+  greenCircle: "\u{1F7E2}\uFE0F",
+  yellowCircle: "\u{1F7E1}\uFE0F",
+  redCircle: "\u{1F534}\uFE0F",
+  fire: "\u{1F525}\uFE0F",
+  speech: "\u{1F4AC}\uFE0F",
+  target: "\u{1F3AF}\uFE0F",
+  key: "\u{1F511}\uFE0F"
+};
+
 // locales/en.json
 var en_default = {
   model: {
@@ -1780,7 +1810,7 @@ function renderSection(name, usage, t, contentFn, hasData = true) {
     return lines;
   }
   if (usage.error || !hasData) {
-    lines.push(`${label} ${colorize(`\u26A0\uFE0F ${t.checkUsage.errorFetching}`, COLORS.pastelYellow)}`);
+    lines.push(`${label} ${colorize(`${ICON.warning} ${t.checkUsage.errorFetching}`, COLORS.pastelYellow)}`);
     return lines;
   }
   lines.push(`${label}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -455,6 +455,36 @@ function getSeparator() {
   return cachedSeparator;
 }
 
+// scripts/utils/emoji.ts
+var ICON = {
+  warning: "\u26A0\uFE0F",
+  gear: "\u2699\uFE0F",
+  alarm: "\u{1F6A8}\uFE0F",
+  stopwatch: "\u23F1\uFE0F",
+  hourglass: "\u23F3\uFE0F",
+  zap: "\u26A1\uFE0F",
+  banknote: "\u{1F4B5}\uFE0F",
+  moneyBag: "\u{1F4B0}\uFE0F",
+  chartUp: "\u{1F4C8}\uFE0F",
+  robot: "\u{1F916}\uFE0F",
+  person: "\u{1F464}\uFE0F",
+  folder: "\u{1F4C1}\uFE0F",
+  tree: "\u{1F333}\uFE0F",
+  label: "\u{1F3F7}\uFE0F",
+  package: "\u{1F4E6}\uFE0F",
+  chart: "\u{1F4CA}\uFE0F",
+  blueDiamond: "\u{1F537}\uFE0F",
+  gem: "\u{1F48E}\uFE0F",
+  orangeCircle: "\u{1F7E0}\uFE0F",
+  greenCircle: "\u{1F7E2}\uFE0F",
+  yellowCircle: "\u{1F7E1}\uFE0F",
+  redCircle: "\u{1F534}\uFE0F",
+  fire: "\u{1F525}\uFE0F",
+  speech: "\u{1F4AC}\uFE0F",
+  target: "\u{1F3AF}\uFE0F",
+  key: "\u{1F511}\uFE0F"
+};
+
 // scripts/utils/api-client.ts
 import { execFile as execFile2 } from "child_process";
 
@@ -1140,7 +1170,7 @@ var modelWidget = {
   },
   render(data) {
     const shortName = shortenModelName(data.displayName);
-    const icon = isZaiProvider() ? "\u{1F7E0}" : "\u25C6";
+    const icon = isZaiProvider() ? ICON.orangeCircle : "\u25C6";
     const supportsEffort = shortName === "Opus" || shortName === "Sonnet";
     const effortSuffix = supportsEffort ? `(${data.effortLevel[0].toUpperCase()})` : "";
     const fastIndicator = shortName === "Opus" && data.fastMode ? " \u21AF" : "";
@@ -1247,7 +1277,7 @@ var costWidget = {
 // scripts/widgets/rate-limit.ts
 function renderRateLimit(data, ctx, labelKey) {
   if (data.isError) {
-    return colorize("\u26A0\uFE0F", getTheme().warning);
+    return colorize(ICON.warning, getTheme().warning);
   }
   const { translations: t } = ctx;
   const color = getColorForPercent(data.utilization);
@@ -1442,7 +1472,7 @@ var projectInfoWidget = {
   render(data, _ctx) {
     const theme = getTheme();
     const parts = [];
-    const dirDisplay = data.subPath ? `\u{1F4C1} ${data.dirName} (${data.subPath})` : `\u{1F4C1} ${data.dirName}`;
+    const dirDisplay = data.subPath ? `${ICON.folder} ${data.dirName} (${data.subPath})` : `${ICON.folder} ${data.dirName}`;
     parts.push(colorize(dirDisplay, theme.folder));
     if (data.gitBranch) {
       let branchStr = data.gitBranch;
@@ -1456,7 +1486,7 @@ var projectInfoWidget = {
       parts.push(colorize(branchDisplay, theme.branch));
     }
     if (data.worktreeName) {
-      parts.push(colorize(`\u{1F333} wt:${data.worktreeName}`, theme.info));
+      parts.push(colorize(`${ICON.tree} wt:${data.worktreeName}`, theme.info));
     }
     return parts.join(" ");
   }
@@ -1711,7 +1741,7 @@ var sessionDurationWidget = {
   render(data, ctx) {
     const { translations: t } = ctx;
     const duration = formatDuration(data.elapsedMs, t.time);
-    return colorize(`\u23F1 ${duration}`, getTheme().secondary);
+    return colorize(`${ICON.stopwatch} ${duration}`, getTheme().secondary);
   }
 };
 
@@ -2039,7 +2069,7 @@ var toolActivityWidget = {
     }
     const runningNames = data.running.slice(0, 2).map((r) => r.target ? `${r.name}(${r.target})` : r.name).join(", ");
     const more = data.running.length > 2 ? ` +${data.running.length - 2}` : "";
-    return `${colorize("\u2699\uFE0F", theme.warning)} ${runningNames}${more} (${data.completed} ${t.widgets.done})`;
+    return `${colorize(ICON.gear, theme.warning)} ${runningNames}${more} (${data.completed} ${t.widgets.done})`;
   }
 };
 
@@ -2069,7 +2099,7 @@ var agentStatusWidget = {
     const activeAgent = data.active[0];
     const agentText = activeAgent.description ? `${activeAgent.name}: ${truncate(activeAgent.description, 20)}` : activeAgent.name;
     const more = data.active.length > 1 ? ` +${data.active.length - 1}` : "";
-    return `${colorize("\u{1F916}", theme.info)} ${t.widgets.agent}: ${agentText}${more}`;
+    return `${colorize(ICON.robot, theme.info)} ${t.widgets.agent}: ${agentText}${more}`;
   }
 };
 
@@ -2131,7 +2161,7 @@ var burnRateWidget = {
     return { tokensPerMinute };
   },
   render(data, _ctx) {
-    return `\u{1F525} ${formatTokens(Math.round(data.tokensPerMinute))}/min`;
+    return `${ICON.fire} ${formatTokens(Math.round(data.tokensPerMinute))}/min`;
   }
 };
 
@@ -2164,7 +2194,7 @@ var depletionTimeWidget = {
   render(data, ctx) {
     const { translations: t } = ctx;
     const duration = formatDuration(data.minutesToLimit * 60 * 1e3, t.time);
-    return colorize(`\u23F3 ~${duration} ${t.widgets.toLimit} ${data.limitType}`, getTheme().warning);
+    return colorize(`${ICON.hourglass} ~${duration} ${t.widgets.toLimit} ${data.limitType}`, getTheme().warning);
   }
 };
 
@@ -2189,7 +2219,7 @@ var cacheHitWidget = {
   },
   render(data) {
     const color = getColorForPercent(100 - data.hitPercentage);
-    return `\u{1F4E6} ${colorize(`${data.hitPercentage}%`, color)}`;
+    return `${ICON.package} ${colorize(`${data.hitPercentage}%`, color)}`;
   }
 };
 
@@ -2486,9 +2516,9 @@ var codexUsageWidget = {
     const { translations: t } = ctx;
     const theme = getTheme();
     const parts = [];
-    parts.push(`${colorize("\u{1F537}", theme.info)} ${data.model}`);
+    parts.push(`${colorize(ICON.blueDiamond, theme.info)} ${data.model}`);
     if (data.isError) {
-      parts.push(colorize("\u26A0\uFE0F", theme.warning));
+      parts.push(colorize(ICON.warning, theme.warning));
     } else {
       if (data.primaryPercent !== null) {
         parts.push(formatRateLimit(t.labels["5h"], data.primaryPercent, data.primaryResetAt, ctx));
@@ -2964,9 +2994,9 @@ var geminiUsageWidget = {
   render(data, ctx) {
     const theme = getTheme();
     const parts = [];
-    parts.push(`${colorize("\u{1F48E}", theme.info)} ${data.model}`);
+    parts.push(`${colorize(ICON.gem, theme.info)} ${data.model}`);
     if (data.isError) {
-      parts.push(colorize("\u26A0\uFE0F", theme.warning));
+      parts.push(colorize(ICON.warning, theme.warning));
     } else if (data.usedPercent !== null) {
       parts.push(formatUsage(data.usedPercent, data.resetAt, ctx));
     }
@@ -3001,10 +3031,10 @@ var geminiUsageAllWidget = {
   render(data, ctx) {
     const theme = getTheme();
     if (data.isError) {
-      return `${colorize("\u{1F48E}", theme.info)} Gemini ${colorize("\u26A0\uFE0F", theme.warning)}`;
+      return `${colorize(ICON.gem, theme.info)} Gemini ${colorize(ICON.warning, theme.warning)}`;
     }
     if (data.buckets.length === 0) {
-      return `${colorize("\u{1F48E}", theme.info)} Gemini ${colorize("--", theme.secondary)}`;
+      return `${colorize(ICON.gem, theme.info)} Gemini ${colorize("--", theme.secondary)}`;
     }
     const parts = data.buckets.map((bucket) => {
       const modelShort = bucket.modelId.replace("gemini-", "");
@@ -3013,7 +3043,7 @@ var geminiUsageAllWidget = {
       }
       return `${colorize(modelShort, theme.secondary)}: ${colorize("--", theme.secondary)}`;
     });
-    return `${colorize("\u{1F48E}", theme.info)} ${parts.join(" \u2502 ")}`;
+    return `${colorize(ICON.gem, theme.info)} ${parts.join(" \u2502 ")}`;
   }
 };
 
@@ -3220,9 +3250,9 @@ var zaiUsageWidget = {
     const { translations: t } = ctx;
     const theme = getTheme();
     const parts = [];
-    parts.push(`\u{1F7E0} ${data.model}`);
+    parts.push(`${ICON.orangeCircle} ${data.model}`);
     if (data.isError) {
-      parts.push(colorize("\u26A0\uFE0F", theme.warning));
+      parts.push(colorize(ICON.warning, theme.warning));
     } else {
       if (data.tokensPercent !== null) {
         let tokenPart = `${t.labels["5h"]}: ${formatPercent(data.tokensPercent)}`;
@@ -3258,7 +3288,7 @@ var sessionIdWidget = {
   name: "Session ID (Short)",
   getData: getSessionIdData,
   render(data) {
-    return colorize(`\u{1F511} ${data.shortId}`, getTheme().secondary);
+    return colorize(`${ICON.key} ${data.shortId}`, getTheme().secondary);
   }
 };
 var sessionIdFullWidget = {
@@ -3266,7 +3296,7 @@ var sessionIdFullWidget = {
   name: "Session ID (Full)",
   getData: getSessionIdData,
   render(data) {
-    return colorize(`\u{1F511} ${data.sessionId}`, getTheme().secondary);
+    return colorize(`${ICON.key} ${data.sessionId}`, getTheme().secondary);
   }
 };
 
@@ -3300,7 +3330,7 @@ var tokenBreakdownWidget = {
       parts.push(`${colorize("W", theme.warning)} ${formatTokens(data.cacheWriteTokens)}`);
     if (data.cacheReadTokens > 0)
       parts.push(`${colorize("R", theme.safe)} ${formatTokens(data.cacheReadTokens)}`);
-    return `\u{1F4CA} ${parts.join(colorize(" \xB7 ", theme.secondary))}`;
+    return `${ICON.chart} ${parts.join(colorize(" \xB7 ", theme.secondary))}`;
   }
 };
 
@@ -3335,13 +3365,13 @@ var performanceWidget = {
     let badge;
     let color;
     if (data.score >= GOOD_THRESHOLD) {
-      badge = "\u{1F7E2}";
+      badge = ICON.greenCircle;
       color = theme.safe;
     } else if (data.score >= OK_THRESHOLD) {
-      badge = "\u{1F7E1}";
+      badge = ICON.yellowCircle;
       color = theme.warning;
     } else {
-      badge = "\u{1F534}";
+      badge = ICON.redCircle;
       color = theme.danger;
     }
     return `${badge} ${colorize(`${data.score}%`, color)}`;
@@ -3378,7 +3408,7 @@ var forecastWidget = {
     } else {
       hourlyColor = theme.safe;
     }
-    return `\u{1F4C8} ${colorize(formatCost(data.currentCost), theme.accent)} \u2192 ${colorize(`~${formatCost(data.hourlyCost)}/h`, hourlyColor)}`;
+    return `${ICON.chartUp} ${colorize(formatCost(data.currentCost), theme.accent)} \u2192 ${colorize(`~${formatCost(data.hourlyCost)}/h`, hourlyColor)}`;
   }
 };
 
@@ -3476,13 +3506,13 @@ var budgetWidget = {
     let icon;
     if (data.utilization >= DANGER_THRESHOLD) {
       color = theme.danger;
-      icon = "\u{1F6A8}";
+      icon = ICON.alarm;
     } else if (data.utilization >= WARNING_THRESHOLD) {
       color = theme.warning;
-      icon = "\u26A0\uFE0F";
+      icon = ICON.warning;
     } else {
       color = theme.safe;
-      icon = "\u{1F4B5}";
+      icon = ICON.banknote;
     }
     return `${icon} ${colorize(`${formatCost(data.dailyTotal)}`, color)} / ${colorize(formatCost(data.dailyBudget), theme.secondary)} ${colorize(`(${percent}%)`, color)}`;
   }
@@ -3575,7 +3605,7 @@ var tokenSpeedWidget = {
     return { tokensPerSecond };
   },
   render(data, _ctx) {
-    return colorize(`\u26A1 ${Math.round(data.tokensPerSecond)} tok/s`, getTheme().accent);
+    return colorize(`${ICON.zap} ${Math.round(data.tokensPerSecond)} tok/s`, getTheme().accent);
   }
 };
 
@@ -3610,7 +3640,7 @@ var todayCostWidget = {
   },
   render(data, ctx) {
     const { translations: t } = ctx;
-    return colorize(`\u{1F4B0} ${t.widgets.todayCost}: ${formatCost(data.dailyTotal)}`, getTheme().secondary);
+    return colorize(`${ICON.moneyBag} ${t.widgets.todayCost}: ${formatCost(data.dailyTotal)}`, getTheme().secondary);
   }
 };
 
@@ -3684,7 +3714,7 @@ var lastPromptWidget = {
   render(data, _ctx) {
     const theme = getTheme();
     const timeStr = new Date(data.timestamp).toTimeString().slice(0, 5);
-    return `\u{1F4AC} ${colorize(timeStr, theme.secondary)} ${truncate(data.text, 60)}`;
+    return `${ICON.speech} ${colorize(timeStr, theme.secondary)} ${truncate(data.text, 60)}`;
   }
 };
 
@@ -3844,7 +3874,7 @@ var tagStatusWidget = {
   },
   render(data, _ctx) {
     const theme = getTheme();
-    const icon = colorize("\u{1F3F7}", theme.info);
+    const icon = colorize(ICON.label, theme.info);
     const parts = data.tags.map(({ name, count }) => {
       const nameColored = colorize(name, theme.branch);
       if (count === 0)
@@ -3866,7 +3896,7 @@ var slashCommandWidget = {
     return getActiveSlashCommand(transcript);
   },
   render(data, _ctx) {
-    return `${colorize("\u{1F3AF}", getTheme().warning)} ${data.name}`;
+    return `${colorize(ICON.target, getTheme().warning)} ${data.name}`;
   }
 };
 
@@ -3887,9 +3917,9 @@ var agentModeWidget = {
   render(data) {
     const parts = [];
     if (data.agentName)
-      parts.push(`\u{1F464} ${data.agentName}`);
+      parts.push(`${ICON.person} ${data.agentName}`);
     if (data.agentType)
-      parts.push(`\u{1F916} ${data.agentType}`);
+      parts.push(`${ICON.robot} ${data.agentType}`);
     return parts.join(" \xB7 ");
   }
 };
@@ -4050,7 +4080,7 @@ async function main() {
   const translations = getTranslations(config);
   const stdin = await readStdin();
   if (!stdin) {
-    console.log(colorize("\u26A0\uFE0F", COLORS.yellow));
+    console.log(colorize(ICON.warning, COLORS.yellow));
     return;
   }
   const stdinLimits = parseStdinRateLimits(stdin);
@@ -4073,5 +4103,5 @@ async function main() {
   console.log(output);
 }
 main().catch(() => {
-  console.log(colorize("\u26A0\uFE0F", COLORS.yellow));
+  console.log(colorize(ICON.warning, COLORS.yellow));
 });

--- a/scripts/__tests__/emoji.test.ts
+++ b/scripts/__tests__/emoji.test.ts
@@ -1,0 +1,22 @@
+/**
+ * @handbook 5.5-emoji-icons
+ * @handbook 8.1-test-structure
+ * @covers scripts/utils/emoji.ts
+ */
+import { describe, it, expect } from 'vitest';
+import { ICON } from '../utils/emoji.js';
+
+describe('ICON registry', () => {
+  it('every value ends with U+FE0F (VS-16) — forces emoji presentation', () => {
+    for (const [key, value] of Object.entries(ICON)) {
+      expect(value, `ICON.${key} must end with U+FE0F`).toMatch(/️$/);
+    }
+  });
+
+  it('every value is a non-empty string', () => {
+    for (const [key, value] of Object.entries(ICON)) {
+      expect(typeof value, `ICON.${key} must be a string`).toBe('string');
+      expect(value.length, `ICON.${key} must not be empty`).toBeGreaterThan(0);
+    }
+  });
+});

--- a/scripts/__tests__/rate-limit.test.ts
+++ b/scripts/__tests__/rate-limit.test.ts
@@ -9,6 +9,7 @@ import {
   rateLimit7dSonnetWidget,
 } from '../widgets/rate-limit.js';
 import type { WidgetContext, UsageLimits, Config } from '../types.js';
+import { ICON } from '../utils/emoji.js';
 import { MOCK_TRANSLATIONS, MOCK_CONFIG, MOCK_STDIN } from './fixtures.js';
 
 // Helper to create widget context
@@ -37,7 +38,7 @@ describe('rate-limit widgets', () => {
       const result = rateLimit5hWidget.render(errorData, ctx);
 
       // Should contain warning emoji (with or without ANSI codes)
-      expect(result).toContain('⚠️');
+      expect(result).toContain(ICON.warning);
     });
 
     it('should return error data when five_hour is not available', async () => {

--- a/scripts/__tests__/session-id.test.ts
+++ b/scripts/__tests__/session-id.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect } from 'vitest';
 import { sessionIdWidget, sessionIdFullWidget } from '../widgets/session-id.js';
 import type { WidgetContext, StdinInput } from '../types.js';
+import { ICON } from '../utils/emoji.js';
 import { MOCK_TRANSLATIONS, MOCK_CONFIG, MOCK_STDIN } from './fixtures.js';
 
 function createStdin(overrides: Partial<StdinInput> = {}): StdinInput {
@@ -46,7 +47,7 @@ describe('sessionIdWidget', () => {
     const data = { sessionId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890', shortId: 'a1b2c3d4' };
     const result = sessionIdWidget.render(data, ctx);
 
-    expect(result).toContain('\u{1F511}');
+    expect(result).toContain(ICON.key);
     expect(result).toContain('a1b2c3d4');
     expect(result).not.toContain('e5f6');
   });
@@ -86,7 +87,7 @@ describe('sessionIdFullWidget', () => {
     const data = { sessionId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890', shortId: 'a1b2c3d4' };
     const result = sessionIdFullWidget.render(data, ctx);
 
-    expect(result).toContain('\u{1F511}');
+    expect(result).toContain(ICON.key);
     expect(result).toContain('a1b2c3d4-e5f6-7890-abcd-ef1234567890');
   });
 });

--- a/scripts/__tests__/widgets.test.ts
+++ b/scripts/__tests__/widgets.test.ts
@@ -72,6 +72,7 @@ import { vimModeWidget } from '../widgets/vim-mode.js';
 import { apiDurationWidget } from '../widgets/api-duration.js';
 import { peakHoursWidget, isPeakTime, getMinutesToTransition } from '../widgets/peak-hours.js';
 import { tagStatusWidget, clearTagCacheForTest } from '../widgets/tag-status.js';
+import { ICON } from '../utils/emoji.js';
 import * as codexClient from '../utils/codex-client.js';
 import * as zaiClient from '../utils/zai-api-client.js';
 import * as historyParser from '../utils/history-parser.js';
@@ -2399,21 +2400,21 @@ describe('widgets', () => {
       const ctx = createContext();
       const data = { agentName: 'my-coder', agentType: 'code-explorer' };
       const result = agentModeWidget.render(data, ctx);
-      expect(result).toContain('👤 my-coder');
-      expect(result).toContain('🤖 code-explorer');
+      expect(result).toContain(`${ICON.person} my-coder`);
+      expect(result).toContain(`${ICON.robot} code-explorer`);
       expect(result).toContain('·');
     });
 
     it('should render only name when type is absent', () => {
       const ctx = createContext();
       const result = agentModeWidget.render({ agentName: 'solo' }, ctx);
-      expect(result).toBe('👤 solo');
+      expect(result).toBe(`${ICON.person} solo`);
     });
 
     it('should render only type when name is absent', () => {
       const ctx = createContext();
       const result = agentModeWidget.render({ agentType: 'code-explorer' }, ctx);
-      expect(result).toBe('🤖 code-explorer');
+      expect(result).toBe(`${ICON.robot} code-explorer`);
     });
 
     it('should return null when agent.name trims to empty string', async () => {

--- a/scripts/__tests__/widgets.test.ts
+++ b/scripts/__tests__/widgets.test.ts
@@ -514,7 +514,7 @@ describe('widgets', () => {
       const data = { dirName: 'my-project', gitBranch: 'main' };
       const result = projectInfoWidget.render(data, ctx);
 
-      expect(result).toContain('📁');
+      expect(result).toContain(ICON.folder);
       expect(result).toContain('my-project');
       expect(result).toContain('main');
     });
@@ -597,7 +597,7 @@ describe('widgets', () => {
       const data = { dirName: 'my-project', gitBranch: 'main', worktreeName: 'my-feature' };
       const result = projectInfoWidget.render(data, ctx);
 
-      expect(result).toContain('🌳');
+      expect(result).toContain(ICON.tree);
       expect(result).toContain('wt:my-feature');
     });
 
@@ -698,7 +698,7 @@ describe('widgets', () => {
 
       expect(result).toContain('Agent');
       expect(result).toContain('Explore');
-      expect(result).toContain('🤖');
+      expect(result).toContain(ICON.robot);
     });
 
     it('should truncate long descriptions', () => {
@@ -749,7 +749,7 @@ describe('widgets', () => {
       expect(result).toContain('Bash');
       expect(result).toContain('Read');
       expect(result).toContain('10');
-      expect(result).toContain('⚙️');
+      expect(result).toContain(ICON.gear);
     });
 
     it('should limit displayed running tools', () => {
@@ -833,7 +833,7 @@ describe('widgets', () => {
       const data = { tokensPerMinute: 5500 };
       const result = burnRateWidget.render(data, ctx);
 
-      expect(result).toContain('🔥');
+      expect(result).toContain(ICON.fire);
       expect(result).toContain('5.5K');
       expect(result).toContain('/min');
     });
@@ -931,7 +931,7 @@ describe('widgets', () => {
       const data = { hitPercentage: 67 };
       const result = cacheHitWidget.render(data, ctx);
 
-      expect(result).toContain('📦');
+      expect(result).toContain(ICON.package);
       expect(result).toContain('67%');
     });
   });
@@ -965,7 +965,7 @@ describe('widgets', () => {
       const data = { minutesToLimit: 120, limitType: '5h' as const };
       const result = depletionTimeWidget.render(data, ctx);
 
-      expect(result).toContain('⏳');
+      expect(result).toContain(ICON.hourglass);
       expect(result).toContain('2h');
       expect(result).toContain('5h');
     });
@@ -1054,7 +1054,7 @@ describe('widgets', () => {
       };
       const result = codexUsageWidget.render(data, ctx);
 
-      expect(result).toContain('🔷');
+      expect(result).toContain(ICON.blueDiamond);
       expect(result).toContain('gpt-5.2-codex');
       expect(result).toContain('5h:');
       expect(result).toContain('25%');
@@ -1090,7 +1090,7 @@ describe('widgets', () => {
       };
       const result = codexUsageWidget.render(data, ctx);
 
-      expect(result).toContain('🔷');
+      expect(result).toContain(ICON.blueDiamond);
       expect(result).toContain('o3');
       expect(result).not.toContain('5h:');
       expect(result).not.toContain('7d:');
@@ -1109,9 +1109,9 @@ describe('widgets', () => {
       };
       const result = codexUsageWidget.render(data, ctx);
 
-      expect(result).toContain('🔷');
+      expect(result).toContain(ICON.blueDiamond);
       expect(result).toContain('codex');
-      expect(result).toContain('⚠️');
+      expect(result).toContain(ICON.warning);
       expect(result).not.toContain('5h:');
       expect(result).not.toContain('7d:');
     });
@@ -1191,7 +1191,7 @@ describe('widgets', () => {
       };
       const result = geminiUsageWidget.render(data, ctx);
 
-      expect(result).toContain('💎');
+      expect(result).toContain(ICON.gem);
       expect(result).toContain('gemini-2.5-pro');
       expect(result).toContain('35%');
     });
@@ -1220,7 +1220,7 @@ describe('widgets', () => {
       };
       const result = geminiUsageWidget.render(data, ctx);
 
-      expect(result).toContain('💎');
+      expect(result).toContain(ICON.gem);
       expect(result).toContain('gemini-3-pro-preview');
       expect(result).not.toContain('%');
     });
@@ -1235,9 +1235,9 @@ describe('widgets', () => {
       };
       const result = geminiUsageWidget.render(data, ctx);
 
-      expect(result).toContain('💎');
+      expect(result).toContain(ICON.gem);
       expect(result).toContain('gemini');
-      expect(result).toContain('⚠️');
+      expect(result).toContain(ICON.warning);
     });
   });
 
@@ -1401,7 +1401,7 @@ describe('widgets', () => {
       const data = { elapsedMs: 3661000 }; // 1h 1m 1s
       const result = sessionDurationWidget.render(data, ctx);
 
-      expect(result).toContain('⏱');
+      expect(result).toContain(ICON.stopwatch);
       expect(result).toContain('1h');
     });
 
@@ -1836,7 +1836,7 @@ describe('widgets', () => {
       const data = { tokensPerSecond: 150 };
       const result = tokenSpeedWidget.render(data, ctx);
 
-      expect(result).toContain('⚡');
+      expect(result).toContain(ICON.zap);
       expect(result).toContain('150 tok/s');
     });
 
@@ -1989,7 +1989,7 @@ describe('widgets', () => {
       const data = { dailyTotal: 3.5 };
       const result = todayCostWidget.render(data, ctx);
 
-      expect(result).toContain('💰');
+      expect(result).toContain(ICON.moneyBag);
       expect(result).toContain('Today');
       expect(result).toContain('$3.50');
     });
@@ -2040,7 +2040,7 @@ describe('widgets', () => {
       const ctx = createContext();
       const data = { dailyTotal: 5, dailyBudget: 20, utilization: 0.25 };
       const result = budgetWidget.render(data, ctx);
-      expect(result).toContain('💵');
+      expect(result).toContain(ICON.banknote);
       expect(result).toContain('$5.00');
       expect(result).toContain('$20.00');
     });
@@ -2049,14 +2049,14 @@ describe('widgets', () => {
       const ctx = createContext();
       const data = { dailyTotal: 17, dailyBudget: 20, utilization: 0.85 };
       const result = budgetWidget.render(data, ctx);
-      expect(result).toContain('⚠️');
+      expect(result).toContain(ICON.warning);
     });
 
     it('should render danger icon for critical utilization', () => {
       const ctx = createContext();
       const data = { dailyTotal: 19.5, dailyBudget: 20, utilization: 0.975 };
       const result = budgetWidget.render(data, ctx);
-      expect(result).toContain('🚨');
+      expect(result).toContain(ICON.alarm);
     });
   });
 
@@ -2087,7 +2087,7 @@ describe('widgets', () => {
       const ctx = createContext();
       const data = { currentCost: 1.5, hourlyCost: 3.0 };
       const result = forecastWidget.render(data, ctx);
-      expect(result).toContain('📈');
+      expect(result).toContain(ICON.chartUp);
       expect(result).toContain('$1.50');
       expect(result).toContain('~$3.00/h');
     });
@@ -2124,7 +2124,7 @@ describe('widgets', () => {
       const ctx = createContext();
       const data = { score: 80, cacheHitRate: 70, outputRatio: 30 };
       const result = performanceWidget.render(data, ctx);
-      expect(result).toContain('🟢');
+      expect(result).toContain(ICON.greenCircle);
       expect(result).toContain('80%');
     });
 
@@ -2132,14 +2132,14 @@ describe('widgets', () => {
       const ctx = createContext();
       const data = { score: 50, cacheHitRate: 40, outputRatio: 20 };
       const result = performanceWidget.render(data, ctx);
-      expect(result).toContain('🟡');
+      expect(result).toContain(ICON.yellowCircle);
     });
 
     it('should render red badge for low score', () => {
       const ctx = createContext();
       const data = { score: 20, cacheHitRate: 10, outputRatio: 10 };
       const result = performanceWidget.render(data, ctx);
-      expect(result).toContain('🔴');
+      expect(result).toContain(ICON.redCircle);
     });
   });
 
@@ -2186,7 +2186,7 @@ describe('widgets', () => {
       const ctx = createContext();
       const data = { inputTokens: 5000, outputTokens: 2000, cacheWriteTokens: 1000, cacheReadTokens: 500 };
       const result = tokenBreakdownWidget.render(data, ctx);
-      expect(result).toContain('📊');
+      expect(result).toContain(ICON.chart);
       expect(result).toContain('In');
       expect(result).toContain('Out');
     });
@@ -2250,8 +2250,8 @@ describe('widgets', () => {
         mcpPercent: null, mcpResetAt: null, isError: true,
       };
       const result = zaiUsageWidget.render(data, ctx);
-      expect(result).toContain('🟠');
-      expect(result).toContain('⚠️');
+      expect(result).toContain(ICON.orangeCircle);
+      expect(result).toContain(ICON.warning);
     });
 
     it('should render usage percentages', () => {
@@ -2261,7 +2261,7 @@ describe('widgets', () => {
         mcpPercent: 20, mcpResetAt: null,
       };
       const result = zaiUsageWidget.render(data, ctx);
-      expect(result).toContain('🟠');
+      expect(result).toContain(ICON.orangeCircle);
       expect(result).toContain('45%');
       expect(result).toContain('20%');
     });
@@ -2296,7 +2296,7 @@ describe('widgets', () => {
       const ctx = createContext();
       const data = { text: 'Fix the login bug', timestamp: '2024-01-01T12:30:00Z' };
       const result = lastPromptWidget.render(data, ctx);
-      expect(result).toContain('💬');
+      expect(result).toContain(ICON.speech);
       expect(result).toContain('Fix the login bug');
     });
 
@@ -2361,7 +2361,7 @@ describe('widgets', () => {
       const ctx = createContext();
       const data = { name: '/foo:bar', startTime: 0 };
       const result = slashCommandWidget.render(data, ctx);
-      expect(result).toContain('🎯');
+      expect(result).toContain(ICON.target);
       expect(result).toContain('/foo:bar');
     });
 

--- a/scripts/check-usage.ts
+++ b/scripts/check-usage.ts
@@ -14,6 +14,7 @@ import { fetchZaiUsage, isZaiInstalled, type ZaiUsageLimits } from './utils/zai-
 import { isZaiProvider } from './utils/provider.js';
 import { formatTimeRemaining } from './utils/formatters.js';
 import { getColorForPercent, colorize, COLORS } from './utils/colors.js';
+import { ICON } from './utils/emoji.js';
 import { getTranslationsByLang, detectSystemLanguage } from './utils/i18n.js';
 import type {
   UsageLimits,
@@ -80,7 +81,7 @@ function renderSection(
   }
 
   if (usage.error || !hasData) {
-    lines.push(`${label} ${colorize(`⚠️ ${t.checkUsage.errorFetching}`, COLORS.pastelYellow)}`);
+    lines.push(`${label} ${colorize(`${ICON.warning} ${t.checkUsage.errorFetching}`, COLORS.pastelYellow)}`);
     return lines;
   }
 

--- a/scripts/statusline.ts
+++ b/scripts/statusline.ts
@@ -15,6 +15,7 @@ import { homedir } from 'os';
 import type { StdinInput, Config, WidgetContext, UsageLimits } from './types.js';
 import { DEFAULT_CONFIG, parsePreset } from './types.js';
 import { COLORS, colorize, setTheme, setSeparatorStyle } from './utils/colors.js';
+import { ICON } from './utils/emoji.js';
 import { fetchUsageLimits } from './utils/api-client.js';
 import { getTranslations } from './utils/i18n.js';
 import { formatOutput } from './widgets/index.js';
@@ -127,7 +128,7 @@ async function main(): Promise<void> {
   // Read stdin
   const stdin = await readStdin();
   if (!stdin) {
-    console.log(colorize('⚠️', COLORS.yellow));
+    console.log(colorize(ICON.warning, COLORS.yellow));
     return;
   }
 
@@ -162,5 +163,5 @@ async function main(): Promise<void> {
 
 // Run
 main().catch(() => {
-  console.log(colorize('⚠️', COLORS.yellow));
+  console.log(colorize(ICON.warning, COLORS.yellow));
 });

--- a/scripts/utils/emoji.ts
+++ b/scripts/utils/emoji.ts
@@ -8,6 +8,13 @@
  * monochrome/colored rendering across users.
  *
  * Always import from here; do not hardcode emoji literals in widgets.
+ *
+ * Excluded by design: non-emoji typographic symbols (`◆ ✓ ↑ ↓ → ↯`) have
+ * Unicode `Emoji=No` — no colored variant exists, VS-16 has no effect on them.
+ * Those literals remain inline in widgets (e.g. `model.ts ◆`, `todo-progress.ts ✓`).
+ *
+ * @handbook 5.5-emoji-icons
+ * @tested scripts/__tests__/emoji.test.ts
  */
 
 export const ICON = {

--- a/scripts/utils/emoji.ts
+++ b/scripts/utils/emoji.ts
@@ -1,0 +1,40 @@
+/**
+ * Centralized emoji icons with VS-16 (U+FE0F) variation selectors.
+ *
+ * Each value ends with an invisible U+FE0F byte — this forces emoji presentation
+ * on terminals whose main monospace font (Nerd Fonts, JetBrains Mono, etc.)
+ * bundles monochrome glyphs for default-emoji codepoints. Without VS-16 the
+ * text glyph wins over the system's color emoji font, producing inconsistent
+ * monochrome/colored rendering across users.
+ *
+ * Always import from here; do not hardcode emoji literals in widgets.
+ */
+
+export const ICON = {
+  warning: '⚠️',
+  gear: '⚙️',
+  alarm: '🚨️',
+  stopwatch: '⏱️',
+  hourglass: '⏳️',
+  zap: '⚡️',
+  banknote: '💵️',
+  moneyBag: '💰️',
+  chartUp: '📈️',
+  robot: '🤖️',
+  person: '👤️',
+  folder: '📁️',
+  tree: '🌳️',
+  label: '🏷️',
+  package: '📦️',
+  chart: '📊️',
+  blueDiamond: '🔷️',
+  gem: '💎️',
+  orangeCircle: '🟠️',
+  greenCircle: '🟢️',
+  yellowCircle: '🟡️',
+  redCircle: '🔴️',
+  fire: '🔥️',
+  speech: '💬️',
+  target: '🎯️',
+  key: '🔑️',
+} as const;

--- a/scripts/widgets/agent-mode.ts
+++ b/scripts/widgets/agent-mode.ts
@@ -13,6 +13,7 @@
 
 import type { Widget } from './base.js';
 import type { WidgetContext, AgentModeData } from '../types.js';
+import { ICON } from '../utils/emoji.js';
 
 export const agentModeWidget: Widget<AgentModeData> = {
   id: 'agentMode',
@@ -30,8 +31,8 @@ export const agentModeWidget: Widget<AgentModeData> = {
 
   render(data: AgentModeData): string {
     const parts: string[] = [];
-    if (data.agentName) parts.push(`👤 ${data.agentName}`);
-    if (data.agentType) parts.push(`🤖 ${data.agentType}`);
+    if (data.agentName) parts.push(`${ICON.person} ${data.agentName}`);
+    if (data.agentType) parts.push(`${ICON.robot} ${data.agentType}`);
     return parts.join(' · ');
   },
 };

--- a/scripts/widgets/agent-status.ts
+++ b/scripts/widgets/agent-status.ts
@@ -7,6 +7,7 @@
 import type { Widget } from './base.js';
 import type { WidgetContext, AgentStatusData } from '../types.js';
 import { colorize, getTheme } from '../utils/colors.js';
+import { ICON } from '../utils/emoji.js';
 import { getTranscript, extractAgentStatus } from '../utils/transcript-parser.js';
 import { truncate } from '../utils/formatters.js';
 
@@ -45,6 +46,6 @@ export const agentStatusWidget: Widget<AgentStatusData> = {
       : activeAgent.name;
     const more = data.active.length > 1 ? ` +${data.active.length - 1}` : '';
 
-    return `${colorize('🤖', theme.info)} ${t.widgets.agent}: ${agentText}${more}`;
+    return `${colorize(ICON.robot, theme.info)} ${t.widgets.agent}: ${agentText}${more}`;
   },
 };

--- a/scripts/widgets/budget.ts
+++ b/scripts/widgets/budget.ts
@@ -7,6 +7,7 @@
 import type { Widget } from './base.js';
 import type { WidgetContext, BudgetData } from '../types.js';
 import { colorize, getTheme } from '../utils/colors.js';
+import { ICON } from '../utils/emoji.js';
 import { formatCost } from '../utils/formatters.js';
 import { recordCostAndGetDaily } from '../utils/budget.js';
 
@@ -41,13 +42,13 @@ export const budgetWidget: Widget<BudgetData> = {
 
     if (data.utilization >= DANGER_THRESHOLD) {
       color = theme.danger;
-      icon = '🚨';
+      icon = ICON.alarm;
     } else if (data.utilization >= WARNING_THRESHOLD) {
       color = theme.warning;
-      icon = '⚠️';
+      icon = ICON.warning;
     } else {
       color = theme.safe;
-      icon = '💵';
+      icon = ICON.banknote;
     }
 
     return `${icon} ${colorize(`${formatCost(data.dailyTotal)}`, color)} / ${colorize(formatCost(data.dailyBudget), theme.secondary)} ${colorize(`(${percent}%)`, color)}`;

--- a/scripts/widgets/burn-rate.ts
+++ b/scripts/widgets/burn-rate.ts
@@ -6,6 +6,7 @@
 
 import type { Widget } from './base.js';
 import type { WidgetContext, BurnRateData } from '../types.js';
+import { ICON } from '../utils/emoji.js';
 import { formatTokens } from '../utils/formatters.js';
 import { getSessionElapsedMinutes } from '../utils/session.js';
 import { debugLog } from '../utils/debug.js';
@@ -53,6 +54,6 @@ export const burnRateWidget: Widget<BurnRateData> = {
   },
 
   render(data: BurnRateData, _ctx: WidgetContext): string {
-    return `🔥 ${formatTokens(Math.round(data.tokensPerMinute))}/min`;
+    return `${ICON.fire} ${formatTokens(Math.round(data.tokensPerMinute))}/min`;
   },
 };

--- a/scripts/widgets/cache-hit.ts
+++ b/scripts/widgets/cache-hit.ts
@@ -7,6 +7,7 @@
 import type { Widget } from './base.js';
 import type { WidgetContext, CacheHitData } from '../types.js';
 import { getColorForPercent, colorize } from '../utils/colors.js';
+import { ICON } from '../utils/emoji.js';
 
 export const cacheHitWidget: Widget<CacheHitData> = {
   id: 'cacheHit',
@@ -40,6 +41,6 @@ export const cacheHitWidget: Widget<CacheHitData> = {
     // Higher cache hit rate is better (green), lower is worse (yellow/red)
     // Invert the color logic: 100% = green, 0% = red
     const color = getColorForPercent(100 - data.hitPercentage);
-    return `📦 ${colorize(`${data.hitPercentage}%`, color)}`;
+    return `${ICON.package} ${colorize(`${data.hitPercentage}%`, color)}`;
   },
 };

--- a/scripts/widgets/codex-usage.ts
+++ b/scripts/widgets/codex-usage.ts
@@ -8,6 +8,7 @@
 import type { Widget } from './base.js';
 import type { WidgetContext, CodexUsageData } from '../types.js';
 import { getColorForPercent, colorize, getTheme } from '../utils/colors.js';
+import { ICON } from '../utils/emoji.js';
 import { isCodexInstalled, fetchCodexUsage } from '../utils/codex-client.js';
 import { formatTimeRemaining } from '../utils/formatters.js';
 import { debugLog } from '../utils/debug.js';
@@ -75,10 +76,10 @@ export const codexUsageWidget: Widget<CodexUsageData> = {
     const theme = getTheme();
     const parts: string[] = [];
 
-    parts.push(`${colorize('🔷', theme.info)} ${data.model}`);
+    parts.push(`${colorize(ICON.blueDiamond, theme.info)} ${data.model}`);
 
     if (data.isError) {
-      parts.push(colorize('⚠️', theme.warning));
+      parts.push(colorize(ICON.warning, theme.warning));
     } else {
       if (data.primaryPercent !== null) {
         parts.push(formatRateLimit(t.labels['5h'], data.primaryPercent, data.primaryResetAt, ctx));

--- a/scripts/widgets/codex-usage.ts
+++ b/scripts/widgets/codex-usage.ts
@@ -49,7 +49,7 @@ export const codexUsageWidget: Widget<CodexUsageData> = {
     const limits = await fetchCodexUsage(ctx.config.cache.ttlSeconds);
     debugLog('codex', 'fetchCodexUsage result:', limits);
     if (!limits) {
-      // Return error state instead of null to show ⚠️ indicator
+      // Return error state instead of null to show warning indicator
       return {
         model: 'codex',
         planType: '',

--- a/scripts/widgets/depletion-time.ts
+++ b/scripts/widgets/depletion-time.ts
@@ -7,6 +7,7 @@
 import type { Widget } from './base.js';
 import type { WidgetContext, DepletionTimeData } from '../types.js';
 import { colorize, getTheme } from '../utils/colors.js';
+import { ICON } from '../utils/emoji.js';
 import { formatDuration } from '../utils/formatters.js';
 import { getSessionElapsedMinutes } from '../utils/session.js';
 
@@ -57,6 +58,6 @@ export const depletionTimeWidget: Widget<DepletionTimeData> = {
   render(data: DepletionTimeData, ctx: WidgetContext): string {
     const { translations: t } = ctx;
     const duration = formatDuration(data.minutesToLimit * 60 * 1000, t.time);
-    return colorize(`⏳ ~${duration} ${t.widgets.toLimit} ${data.limitType}`, getTheme().warning);
+    return colorize(`${ICON.hourglass} ~${duration} ${t.widgets.toLimit} ${data.limitType}`, getTheme().warning);
   },
 };

--- a/scripts/widgets/forecast.ts
+++ b/scripts/widgets/forecast.ts
@@ -7,6 +7,7 @@
 import type { Widget } from './base.js';
 import type { WidgetContext, ForecastData } from '../types.js';
 import { colorize, getTheme } from '../utils/colors.js';
+import { ICON } from '../utils/emoji.js';
 import { formatCost } from '../utils/formatters.js';
 import { getSessionElapsedMinutes } from '../utils/session.js';
 
@@ -44,6 +45,6 @@ export const forecastWidget: Widget<ForecastData> = {
       hourlyColor = theme.safe;
     }
 
-    return `📈 ${colorize(formatCost(data.currentCost), theme.accent)} → ${colorize(`~${formatCost(data.hourlyCost)}/h`, hourlyColor)}`;
+    return `${ICON.chartUp} ${colorize(formatCost(data.currentCost), theme.accent)} → ${colorize(`~${formatCost(data.hourlyCost)}/h`, hourlyColor)}`;
   },
 };

--- a/scripts/widgets/gemini-usage.ts
+++ b/scripts/widgets/gemini-usage.ts
@@ -49,7 +49,7 @@ export const geminiUsageWidget: Widget<GeminiUsageData> = {
     const limits = await fetchGeminiUsage(ctx.config.cache.ttlSeconds);
     debugLog('gemini', 'fetchGeminiUsage result:', limits);
     if (!limits) {
-      // Return error state instead of null to show ⚠️ indicator
+      // Return error state instead of null to show warning indicator
       return {
         model: 'gemini',
         usedPercent: null,

--- a/scripts/widgets/gemini-usage.ts
+++ b/scripts/widgets/gemini-usage.ts
@@ -9,6 +9,7 @@
 import type { Widget } from './base.js';
 import type { WidgetContext, GeminiUsageData, GeminiUsageAllData } from '../types.js';
 import { getColorForPercent, colorize, getTheme } from '../utils/colors.js';
+import { ICON } from '../utils/emoji.js';
 import { isGeminiInstalled, fetchGeminiUsage } from '../utils/gemini-client.js';
 import { formatTimeRemaining } from '../utils/formatters.js';
 import { debugLog } from '../utils/debug.js';
@@ -68,10 +69,10 @@ export const geminiUsageWidget: Widget<GeminiUsageData> = {
     const theme = getTheme();
     const parts: string[] = [];
 
-    parts.push(`${colorize('💎', theme.info)} ${data.model}`);
+    parts.push(`${colorize(ICON.gem, theme.info)} ${data.model}`);
 
     if (data.isError) {
-      parts.push(colorize('⚠️', theme.warning));
+      parts.push(colorize(ICON.warning, theme.warning));
     } else if (data.usedPercent !== null) {
       parts.push(formatUsage(data.usedPercent, data.resetAt, ctx));
     }
@@ -116,11 +117,11 @@ export const geminiUsageAllWidget: Widget<GeminiUsageAllData> = {
     const theme = getTheme();
 
     if (data.isError) {
-      return `${colorize('💎', theme.info)} Gemini ${colorize('⚠️', theme.warning)}`;
+      return `${colorize(ICON.gem, theme.info)} Gemini ${colorize(ICON.warning, theme.warning)}`;
     }
 
     if (data.buckets.length === 0) {
-      return `${colorize('💎', theme.info)} Gemini ${colorize('--', theme.secondary)}`;
+      return `${colorize(ICON.gem, theme.info)} Gemini ${colorize('--', theme.secondary)}`;
     }
 
     const parts = data.buckets.map((bucket) => {
@@ -131,6 +132,6 @@ export const geminiUsageAllWidget: Widget<GeminiUsageAllData> = {
       return `${colorize(modelShort, theme.secondary)}: ${colorize('--', theme.secondary)}`;
     });
 
-    return `${colorize('💎', theme.info)} ${parts.join(' │ ')}`;
+    return `${colorize(ICON.gem, theme.info)} ${parts.join(' │ ')}`;
   },
 };

--- a/scripts/widgets/last-prompt.ts
+++ b/scripts/widgets/last-prompt.ts
@@ -8,6 +8,7 @@
 import type { Widget } from './base.js';
 import type { WidgetContext, LastPromptData } from '../types.js';
 import { colorize, getTheme } from '../utils/colors.js';
+import { ICON } from '../utils/emoji.js';
 import { truncate } from '../utils/formatters.js';
 import { getLastUserPrompt } from '../utils/history-parser.js';
 
@@ -25,6 +26,6 @@ export const lastPromptWidget: Widget<LastPromptData> = {
   render(data: LastPromptData, _ctx: WidgetContext): string {
     const theme = getTheme();
     const timeStr = new Date(data.timestamp).toTimeString().slice(0, 5);
-    return `💬 ${colorize(timeStr, theme.secondary)} ${truncate(data.text, 60)}`;
+    return `${ICON.speech} ${colorize(timeStr, theme.secondary)} ${truncate(data.text, 60)}`;
   },
 };

--- a/scripts/widgets/model.ts
+++ b/scripts/widgets/model.ts
@@ -14,6 +14,7 @@ import { homedir } from 'os';
 import type { Widget } from './base.js';
 import type { WidgetContext, ModelData, EffortLevel } from '../types.js';
 import { RESET, getTheme } from '../utils/colors.js';
+import { ICON } from '../utils/emoji.js';
 import { shortenModelName } from '../utils/formatters.js';
 import { isZaiProvider } from '../utils/provider.js';
 
@@ -96,7 +97,7 @@ export const modelWidget: Widget<ModelData> = {
 
   render(data: ModelData): string {
     const shortName = shortenModelName(data.displayName);
-    const icon = isZaiProvider() ? '🟠' : '◆';
+    const icon = isZaiProvider() ? ICON.orangeCircle : '◆';
 
     // Haiku excluded from effort badge
     const supportsEffort = shortName === 'Opus' || shortName === 'Sonnet';

--- a/scripts/widgets/performance.ts
+++ b/scripts/widgets/performance.ts
@@ -7,6 +7,7 @@
 import type { Widget } from './base.js';
 import type { WidgetContext, PerformanceData } from '../types.js';
 import { colorize, getTheme } from '../utils/colors.js';
+import { ICON } from '../utils/emoji.js';
 import { getSessionElapsedMinutes } from '../utils/session.js';
 
 /**
@@ -54,13 +55,13 @@ export const performanceWidget: Widget<PerformanceData> = {
     let color: string;
 
     if (data.score >= GOOD_THRESHOLD) {
-      badge = '🟢';
+      badge = ICON.greenCircle;
       color = theme.safe;
     } else if (data.score >= OK_THRESHOLD) {
-      badge = '🟡';
+      badge = ICON.yellowCircle;
       color = theme.warning;
     } else {
-      badge = '🔴';
+      badge = ICON.redCircle;
       color = theme.danger;
     }
 

--- a/scripts/widgets/project-info.ts
+++ b/scripts/widgets/project-info.ts
@@ -10,6 +10,7 @@ import { basename, relative } from 'path';
 import type { Widget } from './base.js';
 import type { WidgetContext, ProjectInfoData } from '../types.js';
 import { colorize, getTheme } from '../utils/colors.js';
+import { ICON } from '../utils/emoji.js';
 import { osc8Link } from '../utils/formatters.js';
 import { execGit } from '../utils/git.js';
 
@@ -176,8 +177,8 @@ export const projectInfoWidget: Widget<ProjectInfoData> = {
 
     // Directory name with folder icon, and subpath when CWD differs from project root
     const dirDisplay = data.subPath
-      ? `📁 ${data.dirName} (${data.subPath})`
-      : `📁 ${data.dirName}`;
+      ? `${ICON.folder} ${data.dirName} (${data.subPath})`
+      : `${ICON.folder} ${data.dirName}`;
     parts.push(colorize(dirDisplay, theme.folder));
 
     // Git branch in parentheses with ahead/behind indicators
@@ -201,7 +202,7 @@ export const projectInfoWidget: Widget<ProjectInfoData> = {
 
     // Worktree indicator (only in --worktree sessions)
     if (data.worktreeName) {
-      parts.push(colorize(`🌳 wt:${data.worktreeName}`, theme.info));
+      parts.push(colorize(`${ICON.tree} wt:${data.worktreeName}`, theme.info));
     }
 
     return parts.join(' ');

--- a/scripts/widgets/rate-limit.ts
+++ b/scripts/widgets/rate-limit.ts
@@ -11,6 +11,7 @@
 import type { Widget } from './base.js';
 import type { WidgetContext, RateLimitData, UsageLimits } from '../types.js';
 import { getColorForPercent, colorize, getTheme } from '../utils/colors.js';
+import { ICON } from '../utils/emoji.js';
 import { formatTimeRemaining } from '../utils/formatters.js';
 import { isZaiProvider } from '../utils/provider.js';
 
@@ -19,7 +20,7 @@ type LimitKey = keyof UsageLimits;
 
 function renderRateLimit(data: RateLimitData, ctx: WidgetContext, labelKey: LabelKey): string {
   if (data.isError) {
-    return colorize('⚠️', getTheme().warning);
+    return colorize(ICON.warning, getTheme().warning);
   }
 
   const { translations: t } = ctx;

--- a/scripts/widgets/session-duration.ts
+++ b/scripts/widgets/session-duration.ts
@@ -7,6 +7,7 @@
 import type { Widget } from './base.js';
 import type { WidgetContext, SessionDurationData } from '../types.js';
 import { colorize, getTheme } from '../utils/colors.js';
+import { ICON } from '../utils/emoji.js';
 import { formatDuration } from '../utils/formatters.js';
 import { getSessionElapsedMs } from '../utils/session.js';
 
@@ -31,6 +32,6 @@ export const sessionDurationWidget: Widget<SessionDurationData> = {
   render(data: SessionDurationData, ctx: WidgetContext): string {
     const { translations: t } = ctx;
     const duration = formatDuration(data.elapsedMs, t.time);
-    return colorize(`⏱ ${duration}`, getTheme().secondary);
+    return colorize(`${ICON.stopwatch} ${duration}`, getTheme().secondary);
   },
 };

--- a/scripts/widgets/session-id.ts
+++ b/scripts/widgets/session-id.ts
@@ -8,6 +8,7 @@
 import type { Widget } from './base.js';
 import type { WidgetContext, SessionIdData } from '../types.js';
 import { colorize, getTheme } from '../utils/colors.js';
+import { ICON } from '../utils/emoji.js';
 
 async function getSessionIdData(ctx: WidgetContext): Promise<SessionIdData | null> {
   const sessionId = ctx.stdin.session_id;
@@ -25,7 +26,7 @@ export const sessionIdWidget: Widget<SessionIdData> = {
   getData: getSessionIdData,
 
   render(data: SessionIdData): string {
-    return colorize(`\u{1F511} ${data.shortId}`, getTheme().secondary);
+    return colorize(`${ICON.key} ${data.shortId}`, getTheme().secondary);
   },
 };
 
@@ -35,6 +36,6 @@ export const sessionIdFullWidget: Widget<SessionIdData> = {
   getData: getSessionIdData,
 
   render(data: SessionIdData): string {
-    return colorize(`\u{1F511} ${data.sessionId}`, getTheme().secondary);
+    return colorize(`${ICON.key} ${data.sessionId}`, getTheme().secondary);
   },
 };

--- a/scripts/widgets/slash-command.ts
+++ b/scripts/widgets/slash-command.ts
@@ -9,6 +9,7 @@
 import type { Widget } from './base.js';
 import type { WidgetContext, SlashCommandData } from '../types.js';
 import { colorize, getTheme } from '../utils/colors.js';
+import { ICON } from '../utils/emoji.js';
 import { getTranscript, getActiveSlashCommand } from '../utils/transcript-parser.js';
 
 export const slashCommandWidget: Widget<SlashCommandData> = {
@@ -22,6 +23,6 @@ export const slashCommandWidget: Widget<SlashCommandData> = {
   },
 
   render(data: SlashCommandData, _ctx: WidgetContext): string {
-    return `${colorize('🎯', getTheme().warning)} ${data.name}`;
+    return `${colorize(ICON.target, getTheme().warning)} ${data.name}`;
   },
 };

--- a/scripts/widgets/tag-status.ts
+++ b/scripts/widgets/tag-status.ts
@@ -9,6 +9,7 @@
 import type { Widget } from './base.js';
 import type { WidgetContext, TagStatusData } from '../types.js';
 import { colorize, getTheme } from '../utils/colors.js';
+import { ICON } from '../utils/emoji.js';
 import { execGit } from '../utils/git.js';
 
 const TAG_CACHE_TTL_MS = 30_000;
@@ -74,7 +75,7 @@ export const tagStatusWidget: Widget<TagStatusData> = {
 
   render(data: TagStatusData, _ctx: WidgetContext): string {
     const theme = getTheme();
-    const icon = colorize('🏷', theme.info);
+    const icon = colorize(ICON.label, theme.info);
     const parts = data.tags.map(({ name, count }) => {
       const nameColored = colorize(name, theme.branch);
       if (count === 0) return nameColored;

--- a/scripts/widgets/today-cost.ts
+++ b/scripts/widgets/today-cost.ts
@@ -8,6 +8,7 @@
 import type { Widget } from './base.js';
 import type { WidgetContext, TodayCostData } from '../types.js';
 import { colorize, getTheme } from '../utils/colors.js';
+import { ICON } from '../utils/emoji.js';
 import { formatCost } from '../utils/formatters.js';
 import { recordCostAndGetDaily } from '../utils/budget.js';
 
@@ -27,6 +28,6 @@ export const todayCostWidget: Widget<TodayCostData> = {
 
   render(data: TodayCostData, ctx: WidgetContext): string {
     const { translations: t } = ctx;
-    return colorize(`💰 ${t.widgets.todayCost}: ${formatCost(data.dailyTotal)}`, getTheme().secondary);
+    return colorize(`${ICON.moneyBag} ${t.widgets.todayCost}: ${formatCost(data.dailyTotal)}`, getTheme().secondary);
   },
 };

--- a/scripts/widgets/token-breakdown.ts
+++ b/scripts/widgets/token-breakdown.ts
@@ -7,6 +7,7 @@
 import type { Widget } from './base.js';
 import type { WidgetContext, TokenBreakdownData } from '../types.js';
 import { colorize, getTheme } from '../utils/colors.js';
+import { ICON } from '../utils/emoji.js';
 import { formatTokens } from '../utils/formatters.js';
 
 export const tokenBreakdownWidget: Widget<TokenBreakdownData> = {
@@ -39,6 +40,6 @@ export const tokenBreakdownWidget: Widget<TokenBreakdownData> = {
     if (data.outputTokens > 0) parts.push(`${colorize('Out', theme.accent)} ${formatTokens(data.outputTokens)}`);
     if (data.cacheWriteTokens > 0) parts.push(`${colorize('W', theme.warning)} ${formatTokens(data.cacheWriteTokens)}`);
     if (data.cacheReadTokens > 0) parts.push(`${colorize('R', theme.safe)} ${formatTokens(data.cacheReadTokens)}`);
-    return `📊 ${parts.join(colorize(' · ', theme.secondary))}`;
+    return `${ICON.chart} ${parts.join(colorize(' · ', theme.secondary))}`;
   },
 };

--- a/scripts/widgets/token-speed.ts
+++ b/scripts/widgets/token-speed.ts
@@ -8,6 +8,7 @@
 import type { Widget } from './base.js';
 import type { WidgetContext, TokenSpeedData } from '../types.js';
 import { colorize, getTheme } from '../utils/colors.js';
+import { ICON } from '../utils/emoji.js';
 
 export const tokenSpeedWidget: Widget<TokenSpeedData> = {
   id: 'tokenSpeed',
@@ -27,6 +28,6 @@ export const tokenSpeedWidget: Widget<TokenSpeedData> = {
   },
 
   render(data: TokenSpeedData, _ctx: WidgetContext): string {
-    return colorize(`⚡ ${Math.round(data.tokensPerSecond)} tok/s`, getTheme().accent);
+    return colorize(`${ICON.zap} ${Math.round(data.tokensPerSecond)} tok/s`, getTheme().accent);
   },
 };

--- a/scripts/widgets/tool-activity.ts
+++ b/scripts/widgets/tool-activity.ts
@@ -7,6 +7,7 @@
 import type { Widget } from './base.js';
 import type { WidgetContext, ToolActivityData } from '../types.js';
 import { colorize, getTheme } from '../utils/colors.js';
+import { ICON } from '../utils/emoji.js';
 import {
   getTranscript,
   getRunningTools,
@@ -44,6 +45,6 @@ export const toolActivityWidget: Widget<ToolActivityData> = {
       .join(', ');
     const more = data.running.length > 2 ? ` +${data.running.length - 2}` : '';
 
-    return `${colorize('⚙️', theme.warning)} ${runningNames}${more} (${data.completed} ${t.widgets.done})`;
+    return `${colorize(ICON.gear, theme.warning)} ${runningNames}${more} (${data.completed} ${t.widgets.done})`;
   },
 };

--- a/scripts/widgets/zai-usage.ts
+++ b/scripts/widgets/zai-usage.ts
@@ -8,6 +8,7 @@
 import type { Widget } from './base.js';
 import type { WidgetContext, ZaiUsageData } from '../types.js';
 import { getColorForPercent, colorize, getTheme } from '../utils/colors.js';
+import { ICON } from '../utils/emoji.js';
 import { formatTimeRemaining } from '../utils/formatters.js';
 import { isZaiInstalled, fetchZaiUsage } from '../utils/zai-api-client.js';
 import { debugLog } from '../utils/debug.js';
@@ -62,10 +63,10 @@ export const zaiUsageWidget: Widget<ZaiUsageData> = {
     const theme = getTheme();
     const parts: string[] = [];
 
-    parts.push(`🟠 ${data.model}`);
+    parts.push(`${ICON.orangeCircle} ${data.model}`);
 
     if (data.isError) {
-      parts.push(colorize('⚠️', theme.warning));
+      parts.push(colorize(ICON.warning, theme.warning));
     } else {
       // 5-hour token usage
       if (data.tokensPercent !== null) {


### PR DESCRIPTION
Introduces scripts/utils/emoji.ts as the single source for all status-line emoji. Every value carries a trailing U+FE0F (VS-16) so terminals choose the color emoji glyph over monochrome fallbacks bundled in programming fonts (Nerd Fonts, JetBrains Mono, etc.). Previously some icons rendered colored while others fell back to mono line-art depending on the user's font stack — most visibly ⏱ and 🏷, which lacked VS-16 entirely.

Replaces 26 hardcoded emoji literals across 22 widgets plus the two entry points. Non-emoji decorative symbols (◆ ✓ ↑ ↓ → ↯) are intentionally left untouched — they have no colored variant.

## Summary

<!-- Brief description of what this PR does -->

## Changes

-

## Test Plan

- [ ] Tested locally with `npm run test`
- [ ] Verified status line output format
- [ ] Checked i18n (en/ko)

## Screenshots (if applicable)

<!-- Before/After screenshots of status line output -->
