### PR TITLE
fix: respect CLAUDE_CONFIG_DIR across config reads, caches, and setup commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ claude-dashboard.mov
 website/node_modules/
 website/dist/
 website/.astro/
+
+graphify-out/
+.superpowers

--- a/README.md
+++ b/README.md
@@ -255,7 +255,8 @@ The status line follows the same variable, so each session reports the account t
 Notes:
 
 - The variable must be a single directory path, and must be exported to the session.
-- On macOS the OAuth token comes from the Keychain, which holds one entry for all accounts — there `CLAUDE_CONFIG_DIR` separates settings and history but not usage data.
+- On macOS the OAuth token comes from the Keychain, which holds one entry for all accounts — `CLAUDE_CONFIG_DIR` separates `settings.json` and `history.jsonl` reads, but rate-limit API calls use whichever OAuth token the Keychain holds.
+- `/claude-dashboard:setup` currently registers the status line into `~/.claude/settings.json` only — with `CLAUDE_CONFIG_DIR` set, copy the resulting `statusLine` block into the relocated `settings.json` yourself.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,25 @@ Update the plugin and refresh the statusLine path in settings. Run after updatin
 </details>
 
 <details>
+<summary><strong>Multiple accounts (CLAUDE_CONFIG_DIR)</strong></summary>
+
+Claude Code relocates its whole config directory — credentials, settings, and history — when `CLAUDE_CONFIG_DIR` is set. That is how two accounts run side by side:
+
+```bash
+# Personal Max account, kept separate from the default ~/.claude
+CLAUDE_CONFIG_DIR=~/.claude-max claude
+```
+
+The status line follows the same variable, so each session reports the account that is actually rendering it. Leave it unset and the default `~/.claude` is used, as before.
+
+Notes:
+
+- The variable must be a single directory path, and must be exported to the session.
+- On macOS the OAuth token comes from the Keychain, which holds one entry for all accounts — there `CLAUDE_CONFIG_DIR` separates settings and history but not usage data.
+
+</details>
+
+<details>
 <summary><strong>Wrong language</strong></summary>
 
 Run setup with explicit language:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Comprehensive status line plugin for Claude Code — unified usage monitoring ac
 ### Manual Installation
 
 ```bash
-git clone https://github.com/uppinote20/claude-dashboard.git ~/.claude/plugins/claude-dashboard
+git clone https://github.com/uppinote20/claude-dashboard.git "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/claude-dashboard"
 /claude-dashboard:setup
 ```
 
@@ -256,7 +256,7 @@ Notes:
 
 - The variable must be a single directory path, and must be exported to the session.
 - On macOS the OAuth token comes from the Keychain, which holds one entry for all accounts — `CLAUDE_CONFIG_DIR` separates `settings.json` and `history.jsonl` reads, but rate-limit API calls use whichever OAuth token the Keychain holds.
-- `/claude-dashboard:setup` currently registers the status line into `~/.claude/settings.json` only — with `CLAUDE_CONFIG_DIR` set, copy the resulting `statusLine` block into the relocated `settings.json` yourself.
+- `/claude-dashboard:setup` and `/claude-dashboard:update` register the status line into the session's config dir (`$CLAUDE_CONFIG_DIR` if set, `~/.claude` otherwise) — run them once per account. The dashboard's own display config `~/.claude/claude-dashboard.local.json` is intentionally shared across accounts.
 
 </details>
 

--- a/commands/check-usage.md
+++ b/commands/check-usage.md
@@ -36,7 +36,7 @@ At the bottom, recommends the CLI with the lowest current usage.
 ### 1. Find plugin path and run check-usage script
 
 ```bash
-node "$(ls -d ~/.claude/plugins/cache/claude-dashboard/claude-dashboard/*/dist/check-usage.js 2>/dev/null | sort -V | tail -1)" $ARGUMENTS
+node "$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/claude-dashboard/claude-dashboard/*/dist/check-usage.js 2>/dev/null | sort -V | tail -1)" $ARGUMENTS
 ```
 
 This will:

--- a/commands/setup-alias.md
+++ b/commands/setup-alias.md
@@ -50,7 +50,7 @@ grep -q "^check-ai()" ~/.zshrc 2>/dev/null && echo "exists" || echo "not found"
 ```bash
 # Claude Dashboard - check-ai alias
 check-ai() {
-  node "$(ls -d ~/.claude/plugins/cache/claude-dashboard/claude-dashboard/*/dist/check-usage.js 2>/dev/null | sort -V | tail -1)" "$@"
+  node "$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/claude-dashboard/claude-dashboard/*/dist/check-usage.js 2>/dev/null | sort -V | tail -1)" "$@"
 }
 ```
 
@@ -60,7 +60,7 @@ cat >> ~/.zshrc << 'EOF'
 
 # Claude Dashboard - check-ai alias
 check-ai() {
-  node "$(ls -d ~/.claude/plugins/cache/claude-dashboard/claude-dashboard/*/dist/check-usage.js 2>/dev/null | sort -V | tail -1)" "$@"
+  node "$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/claude-dashboard/claude-dashboard/*/dist/check-usage.js 2>/dev/null | sort -V | tail -1)" "$@"
 }
 EOF
 ```
@@ -81,7 +81,8 @@ powershell -Command "if (Test-Path $PROFILE) { Select-String -Path $PROFILE -Pat
 ```powershell
 # Claude Dashboard - check-ai alias
 function check-ai {
-  $script = (Get-ChildItem "$env:USERPROFILE\.claude\plugins\cache\claude-dashboard\claude-dashboard\*\dist\check-usage.js" | Sort-Object { [version]$_.Directory.Parent.Name } | Select-Object -Last 1).FullName
+  $base = if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { "$env:USERPROFILE\.claude" }
+  $script = (Get-ChildItem "$base\plugins\cache\claude-dashboard\claude-dashboard\*\dist\check-usage.js" | Sort-Object { [version]$_.Directory.Parent.Name } | Select-Object -Last 1).FullName
   node $script $args
 }
 ```
@@ -92,7 +93,8 @@ powershell -Command "Add-Content -Path $PROFILE -Value @'
 
 # Claude Dashboard - check-ai alias
 function check-ai {
-  `$script = (Get-ChildItem \"`$env:USERPROFILE\.claude\plugins\cache\claude-dashboard\claude-dashboard\*\dist\check-usage.js\" | Sort-Object { [version]`$_.Directory.Parent.Name } | Select-Object -Last 1).FullName
+  `$base = if (`$env:CLAUDE_CONFIG_DIR) { `$env:CLAUDE_CONFIG_DIR } else { \"`$env:USERPROFILE\.claude\" }
+  `$script = (Get-ChildItem \"`$base\plugins\cache\claude-dashboard\claude-dashboard\*\dist\check-usage.js\" | Sort-Object { [version]`$_.Directory.Parent.Name } | Select-Object -Last 1).FullName
   node `$script `$args
 }
 '@"

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -163,6 +163,8 @@ Use the provided arguments directly.
 
 Create `~/.claude/claude-dashboard.local.json`:
 
+> This file intentionally stays in `~/.claude` even when `CLAUDE_CONFIG_DIR` is set — it is the dashboard's own display config, shared by every account, and the statusline always reads it from there.
+
 **For preset modes (compact/normal/detailed):**
 ```json
 {
@@ -230,16 +232,16 @@ Preset characters: `M`=model, `C`=context, `b`=contextBar, `%`=contextPercentage
 
 ### 3. Update settings.json
 
-Add or update the statusLine configuration in `~/.claude/settings.json`:
+Add or update the statusLine configuration in the session's Claude config dir — `$CLAUDE_CONFIG_DIR` if set, `~/.claude` otherwise. Multi-account setups run this once per account:
 
 **Find the plugin path and update settings.json** (copy-paste one-liner):
 ```bash
-SLPATH="$(ls -d ~/.claude/plugins/cache/claude-dashboard/claude-dashboard/*/dist/index.js 2>/dev/null | sort -V | tail -1)" node -e 'const fs=require("fs"),os=require("os"),p=os.homedir()+"/.claude/settings.json";const s=fs.existsSync(p)?JSON.parse(fs.readFileSync(p,"utf8")):{};s.statusLine={type:"command",command:"node "+process.env.SLPATH};fs.writeFileSync(p,JSON.stringify(s,null,2));'
+CFGDIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"; SLPATH="$(ls -d "$CFGDIR"/plugins/cache/claude-dashboard/claude-dashboard/*/dist/index.js 2>/dev/null | sort -V | tail -1)" CFGDIR="$CFGDIR" node -e 'const fs=require("fs"),p=process.env.CFGDIR+"/settings.json";const s=fs.existsSync(p)?JSON.parse(fs.readFileSync(p,"utf8")):{};s.statusLine={type:"command",command:"node "+process.env.SLPATH};fs.writeFileSync(p,JSON.stringify(s,null,2));'
 ```
 
 This command:
-1. Finds the latest plugin version dynamically
-2. Updates `statusLine` in settings.json with the correct path
+1. Finds the latest plugin version dynamically (in `$CLAUDE_CONFIG_DIR` when set, `~/.claude` otherwise)
+2. Updates `statusLine` in that config dir's settings.json with the correct path
 
 **IMPORTANT**: After updating the plugin via `/plugin update claude-dashboard`, run `/claude-dashboard:update` to update the statusLine path to the latest version.
 

--- a/commands/update.md
+++ b/commands/update.md
@@ -13,13 +13,14 @@ Run this command after updating the plugin via `/plugin update claude-dashboard`
 
 1. Find the latest version in the plugin cache:
 ```bash
-ls -d ~/.claude/plugins/cache/claude-dashboard/claude-dashboard/*/ 2>/dev/null | grep -E '/[0-9]+\.[0-9]+\.[0-9]+/$' | sort -V | tail -1
+ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/claude-dashboard/claude-dashboard/*/ 2>/dev/null | grep -E '/[0-9]+\.[0-9]+\.[0-9]+/$' | sort -V | tail -1
 ```
 
 2. Update settings.json with the latest version path:
 ```bash
-LATEST_VERSION=$(ls -d ~/.claude/plugins/cache/claude-dashboard/claude-dashboard/*/ 2>/dev/null | grep -E '/[0-9]+\.[0-9]+\.[0-9]+/$' | sort -V | tail -1 | xargs basename)
-NEWCMD="node ~/.claude/plugins/cache/claude-dashboard/claude-dashboard/${LATEST_VERSION}/dist/index.js" node -e 'const fs=require("fs"),os=require("os"),p=os.homedir()+"/.claude/settings.json";const s=JSON.parse(fs.readFileSync(p,"utf8"));s.statusLine=s.statusLine||{type:"command"};s.statusLine.command=process.env.NEWCMD;fs.writeFileSync(p,JSON.stringify(s,null,2));'
+CFGDIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+LATEST_VERSION=$(ls -d "$CFGDIR"/plugins/cache/claude-dashboard/claude-dashboard/*/ 2>/dev/null | grep -E '/[0-9]+\.[0-9]+\.[0-9]+/$' | sort -V | tail -1 | xargs basename)
+NEWCMD="node $CFGDIR/plugins/cache/claude-dashboard/claude-dashboard/${LATEST_VERSION}/dist/index.js" CFGDIR="$CFGDIR" node -e 'const fs=require("fs"),p=process.env.CFGDIR+"/settings.json";const s=JSON.parse(fs.readFileSync(p,"utf8"));s.statusLine=s.statusLine||{type:"command"};s.statusLine.command=process.env.NEWCMD;fs.writeFileSync(p,JSON.stringify(s,null,2));'
 ```
 
 3. Show the user what was updated:
@@ -32,6 +33,7 @@ NEWCMD="node ~/.claude/plugins/cache/claude-dashboard/claude-dashboard/${LATEST_
 ```
 Updated statusLine to version 1.7.0
 Path: ~/.claude/plugins/cache/claude-dashboard/claude-dashboard/1.7.0/dist/index.js
+(with CLAUDE_CONFIG_DIR set, the path is under that directory instead)
 
 Restart Claude Code for changes to take effect.
 ```

--- a/dist/check-usage.js
+++ b/dist/check-usage.js
@@ -14,8 +14,10 @@ import { join as join2 } from "path";
 // scripts/utils/config-dir.ts
 import { join } from "path";
 import { homedir } from "os";
+var DEFAULT_CONFIG_DIR = join(homedir(), ".claude");
+var DEFAULT_CLAUDE_JSON_PATH = join(homedir(), ".claude.json");
 function getClaudeConfigDir() {
-  return process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
+  return process.env.CLAUDE_CONFIG_DIR || DEFAULT_CONFIG_DIR;
 }
 
 // scripts/utils/credentials.ts
@@ -72,13 +74,13 @@ async function getCredentialsFromFile() {
     const credPath = join2(getClaudeConfigDir(), ".credentials.json");
     const fileStat = await stat(credPath);
     const mtime = fileStat.mtimeMs;
-    if (credentialsCache?.mtime === mtime) {
+    if (credentialsCache?.path === credPath && credentialsCache.mtime === mtime) {
       return credentialsCache.token;
     }
     const content = await readFile(credPath, "utf-8");
     const creds = JSON.parse(content);
     const token = creds?.claudeAiOauth?.accessToken ?? null;
-    credentialsCache = { token, mtime };
+    credentialsCache = { token, path: credPath, mtime };
     return token;
   } catch {
     return null;

--- a/dist/check-usage.js
+++ b/dist/check-usage.js
@@ -9,8 +9,16 @@ var NEGATIVE_CACHE_SECONDS = 30;
 // scripts/utils/credentials.ts
 import { execFile } from "child_process";
 import { readFile, stat } from "fs/promises";
+import { join as join2 } from "path";
+
+// scripts/utils/config-dir.ts
 import { join } from "path";
 import { homedir } from "os";
+function getClaudeConfigDir() {
+  return process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
+}
+
+// scripts/utils/credentials.ts
 var KEYCHAIN_CACHE_TTL_MS = 1e4;
 var KEYCHAIN_BACKOFF_MS = 6e4;
 var credentialsCache = null;
@@ -61,7 +69,7 @@ async function getCredentialsFromKeychain() {
 }
 async function getCredentialsFromFile() {
   try {
-    const credPath = join(homedir(), ".claude", ".credentials.json");
+    const credPath = join2(getClaudeConfigDir(), ".credentials.json");
     const fileStat = await stat(credPath);
     const mtime = fileStat.mtimeMs;
     if (credentialsCache?.mtime === mtime) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -497,12 +497,14 @@ import { join as join2 } from "path";
 // scripts/utils/config-dir.ts
 import { join } from "path";
 import { homedir } from "os";
+var DEFAULT_CONFIG_DIR = join(homedir(), ".claude");
+var DEFAULT_CLAUDE_JSON_PATH = join(homedir(), ".claude.json");
 function getClaudeConfigDir() {
-  return process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
+  return process.env.CLAUDE_CONFIG_DIR || DEFAULT_CONFIG_DIR;
 }
 function getClaudeJsonPath() {
   const configDir = process.env.CLAUDE_CONFIG_DIR;
-  return configDir ? join(configDir, ".claude.json") : join(homedir(), ".claude.json");
+  return configDir ? join(configDir, ".claude.json") : DEFAULT_CLAUDE_JSON_PATH;
 }
 
 // scripts/utils/credentials.ts
@@ -559,13 +561,13 @@ async function getCredentialsFromFile() {
     const credPath = join2(getClaudeConfigDir(), ".credentials.json");
     const fileStat = await stat(credPath);
     const mtime = fileStat.mtimeMs;
-    if (credentialsCache?.mtime === mtime) {
+    if (credentialsCache?.path === credPath && credentialsCache.mtime === mtime) {
       return credentialsCache.token;
     }
     const content = await readFile(credPath, "utf-8");
     const creds = JSON.parse(content);
     const token = creds?.claudeAiOauth?.accessToken ?? null;
-    credentialsCache = { token, mtime };
+    credentialsCache = { token, path: credPath, mtime };
     return token;
   } catch {
     return null;
@@ -1164,7 +1166,7 @@ async function getModelSettings(modelId) {
   const settingsPath = join3(getClaudeConfigDir(), "settings.json");
   try {
     const fileStat = await stat3(settingsPath);
-    if (settingsCache && settingsCache.mtime === fileStat.mtimeMs) {
+    if (settingsCache && settingsCache.path === settingsPath && settingsCache.mtime === fileStat.mtimeMs) {
       return {
         effortLevel: isEffortLevel(settingsCache.rawEffort) ? settingsCache.rawEffort : defaultEffort,
         fastMode: settingsCache.fastMode
@@ -1174,7 +1176,7 @@ async function getModelSettings(modelId) {
     const settings = JSON.parse(content);
     const rawEffort = settings.effortLevel;
     const fastMode = settings.fastMode === true;
-    settingsCache = { mtime: fileStat.mtimeMs, rawEffort, fastMode };
+    settingsCache = { path: settingsPath, mtime: fileStat.mtimeMs, rawEffort, fastMode };
     return {
       effortLevel: isEffortLevel(rawEffort) ? rawEffort : defaultEffort,
       fastMode
@@ -3710,13 +3712,12 @@ async function getLastUserPrompt(sessionId) {
   try {
     const historyPath = join7(getClaudeConfigDir(), "history.jsonl");
     const fileStat = await stat9(historyPath);
-    if (historyCache && historyCache.fileSize === fileStat.size) {
+    if (historyCache && historyCache.path === historyPath && historyCache.fileSize === fileStat.size) {
       const cached = historyCache.results.get(sessionId);
       if (cached !== void 0)
         return cached;
-    }
-    if (!historyCache || historyCache.fileSize !== fileStat.size) {
-      historyCache = { fileSize: fileStat.size, results: /* @__PURE__ */ new Map() };
+    } else {
+      historyCache = { path: historyPath, fileSize: fileStat.size, results: /* @__PURE__ */ new Map() };
     }
     const size = Math.min(CHUNK, fileStat.size);
     const fd = await open3(historyPath, "r");

--- a/dist/index.js
+++ b/dist/index.js
@@ -2,8 +2,8 @@
 
 // scripts/statusline.ts
 import { readFile as readFile9, stat as stat10 } from "fs/promises";
-import { join as join6 } from "path";
-import { homedir as homedir6 } from "os";
+import { join as join8 } from "path";
+import { homedir as homedir4 } from "os";
 
 // scripts/types.ts
 var DISPLAY_PRESETS = {
@@ -492,8 +492,20 @@ import { execFile as execFile2 } from "child_process";
 // scripts/utils/credentials.ts
 import { execFile } from "child_process";
 import { readFile, stat } from "fs/promises";
+import { join as join2 } from "path";
+
+// scripts/utils/config-dir.ts
 import { join } from "path";
 import { homedir } from "os";
+function getClaudeConfigDir() {
+  return process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
+}
+function getClaudeJsonPath() {
+  const configDir = process.env.CLAUDE_CONFIG_DIR;
+  return configDir ? join(configDir, ".claude.json") : join(homedir(), ".claude.json");
+}
+
+// scripts/utils/credentials.ts
 var KEYCHAIN_CACHE_TTL_MS = 1e4;
 var KEYCHAIN_BACKOFF_MS = 6e4;
 var credentialsCache = null;
@@ -544,7 +556,7 @@ async function getCredentialsFromKeychain() {
 }
 async function getCredentialsFromFile() {
   try {
-    const credPath = join(homedir(), ".claude", ".credentials.json");
+    const credPath = join2(getClaudeConfigDir(), ".credentials.json");
     const fileStat = await stat(credPath);
     const mtime = fileStat.mtimeMs;
     if (credentialsCache?.mtime === mtime) {
@@ -1022,8 +1034,7 @@ function getTranslations(config) {
 
 // scripts/widgets/model.ts
 import { readFile as readFile3, stat as stat3 } from "fs/promises";
-import { join as join2 } from "path";
-import { homedir as homedir2 } from "os";
+import { join as join3 } from "path";
 
 // scripts/utils/formatters.ts
 function formatTokens(tokens) {
@@ -1150,7 +1161,7 @@ function getDefaultEffort(_modelId) {
 var settingsCache = null;
 async function getModelSettings(modelId) {
   const defaultEffort = getDefaultEffort(modelId);
-  const settingsPath = join2(homedir2(), ".claude", "settings.json");
+  const settingsPath = join3(getClaudeConfigDir(), "settings.json");
   try {
     const fileStat = await stat3(settingsPath);
     if (settingsCache && settingsCache.mtime === fileStat.mtimeMs) {
@@ -1531,7 +1542,7 @@ var projectInfoWidget = {
 
 // scripts/widgets/config-counts.ts
 import { readdir as readdir2, readFile as readFile4, stat as stat4 } from "fs/promises";
-import { join as join3 } from "path";
+import { join as join4 } from "path";
 var CONFIG_CACHE_TTL_MS = 3e4;
 var EMPTY_FS_COUNTS = { claudeMd: 0, agentsMd: 0, rules: 0, mcps: 0, hooks: 0 };
 var configCountsCache = null;
@@ -1556,24 +1567,25 @@ async function fileExists(path4) {
 }
 async function countClaudeMd(projectDir) {
   const [root, nested] = await Promise.all([
-    fileExists(join3(projectDir, "CLAUDE.md")),
-    fileExists(join3(projectDir, ".claude", "CLAUDE.md"))
+    fileExists(join4(projectDir, "CLAUDE.md")),
+    fileExists(join4(projectDir, ".claude", "CLAUDE.md"))
   ]);
   return (root ? 1 : 0) + (nested ? 1 : 0);
 }
 async function countAgentsMd(projectDir) {
   const [root, agentFiles] = await Promise.all([
-    fileExists(join3(projectDir, "AGENTS.md")),
-    countFiles(join3(projectDir, ".claude", "agents"), /\.md$/)
+    fileExists(join4(projectDir, "AGENTS.md")),
+    countFiles(join4(projectDir, ".claude", "agents"), /\.md$/)
   ]);
   return (root ? 1 : 0) + agentFiles;
 }
 async function countMcps(projectDir) {
   const homeDir = process.env.HOME || "";
   const mcpPaths = [
-    { path: join3(projectDir, ".claude", "mcp.json"), key: "mcpServers" },
-    { path: join3(homeDir, ".claude.json"), key: "mcpServers" },
-    { path: join3(homeDir, ".config", "claude-code", "mcp.json"), key: "mcpServers" }
+    { path: join4(projectDir, ".claude", "mcp.json"), key: "mcpServers" },
+    // Global MCP config follows CLAUDE_CONFIG_DIR; the XDG path below does not.
+    { path: getClaudeJsonPath(), key: "mcpServers" },
+    { path: join4(homeDir, ".config", "claude-code", "mcp.json"), key: "mcpServers" }
   ];
   const counts = await Promise.all(
     mcpPaths.map(async ({ path: path4, key }) => {
@@ -1603,13 +1615,13 @@ var configCountsWidget = {
       const fsData2 = configCountsCache.data ?? EMPTY_FS_COUNTS;
       return { ...fsData2, addedDirs };
     }
-    const claudeDir = join3(currentDir, ".claude");
+    const claudeDir = join4(currentDir, ".claude");
     const [claudeMd, agentsMd, rules, mcps, hooks] = await Promise.all([
       countClaudeMd(currentDir),
       countAgentsMd(currentDir),
-      countFiles(join3(claudeDir, "rules")),
+      countFiles(join4(claudeDir, "rules")),
       countMcps(currentDir),
-      countFiles(join3(claudeDir, "hooks"))
+      countFiles(join4(claudeDir, "hooks"))
     ]);
     const fsData = claudeMd === 0 && agentsMd === 0 && rules === 0 && mcps === 0 && hooks === 0 ? null : { claudeMd, agentsMd, rules, mcps, hooks };
     configCountsCache = { projectDir: currentDir, data: fsData, timestamp: Date.now() };
@@ -1644,9 +1656,9 @@ var configCountsWidget = {
 
 // scripts/utils/session.ts
 import { readFile as readFile5, mkdir as mkdir2, open, readdir as readdir3, unlink as unlink2, stat as stat5 } from "fs/promises";
-import { join as join4 } from "path";
-import { homedir as homedir3 } from "os";
-var SESSION_DIR = join4(homedir3(), ".cache", "claude-dashboard", "sessions");
+import { join as join5 } from "path";
+import { homedir as homedir2 } from "os";
+var SESSION_DIR = join5(homedir2(), ".cache", "claude-dashboard", "sessions");
 var SESSION_MAX_AGE_SECONDS = 604800;
 var CLEANUP_INTERVAL_MS2 = 36e5;
 function isErrnoException(error, code) {
@@ -1676,7 +1688,7 @@ async function getSessionStartTime(sessionId) {
   }
 }
 async function getOrCreateSessionStartTimeImpl(safeSessionId) {
-  const sessionFile = join4(SESSION_DIR, `${safeSessionId}.json`);
+  const sessionFile = join5(SESSION_DIR, `${safeSessionId}.json`);
   try {
     const content = await readFile5(sessionFile, "utf-8");
     const data = JSON.parse(content);
@@ -1749,7 +1761,7 @@ async function cleanupExpiredSessions() {
       if (!file.endsWith(".json"))
         continue;
       try {
-        const filePath = join4(SESSION_DIR, file);
+        const filePath = join5(SESSION_DIR, file);
         const fileStat = await stat5(filePath);
         if (fileStat.mtimeMs < cutoffTime) {
           await unlink2(filePath);
@@ -3451,10 +3463,10 @@ var forecastWidget = {
 
 // scripts/utils/budget.ts
 import { readFile as readFile8, mkdir as mkdir4, writeFile as writeFile4 } from "fs/promises";
-import { join as join5 } from "path";
-import { homedir as homedir4 } from "os";
-var BUDGET_DIR = join5(homedir4(), ".cache", "claude-dashboard");
-var BUDGET_FILE = join5(BUDGET_DIR, "budget.json");
+import { join as join6 } from "path";
+import { homedir as homedir3 } from "os";
+var BUDGET_DIR = join6(homedir3(), ".cache", "claude-dashboard");
+var BUDGET_FILE = join6(BUDGET_DIR, "budget.json");
 var budgetCache = null;
 var dirEnsured = false;
 var pendingRecordDaily = null;
@@ -3683,8 +3695,7 @@ var todayCostWidget = {
 
 // scripts/utils/history-parser.ts
 import { open as open3, stat as stat9 } from "fs/promises";
-import { homedir as homedir5 } from "os";
-var HISTORY_PATH = `${homedir5()}/.claude/history.jsonl`;
+import { join as join7 } from "path";
 var CHUNK = 16 * 1024;
 function resolvePastedText(display, pastedContents) {
   if (!pastedContents)
@@ -3697,7 +3708,8 @@ function resolvePastedText(display, pastedContents) {
 var historyCache = null;
 async function getLastUserPrompt(sessionId) {
   try {
-    const fileStat = await stat9(HISTORY_PATH);
+    const historyPath = join7(getClaudeConfigDir(), "history.jsonl");
+    const fileStat = await stat9(historyPath);
     if (historyCache && historyCache.fileSize === fileStat.size) {
       const cached = historyCache.results.get(sessionId);
       if (cached !== void 0)
@@ -3707,7 +3719,7 @@ async function getLastUserPrompt(sessionId) {
       historyCache = { fileSize: fileStat.size, results: /* @__PURE__ */ new Map() };
     }
     const size = Math.min(CHUNK, fileStat.size);
-    const fd = await open3(HISTORY_PATH, "r");
+    const fd = await open3(historyPath, "r");
     try {
       const buffer = Buffer.alloc(size);
       await fd.read(buffer, 0, size, fileStat.size - size);
@@ -4054,7 +4066,7 @@ async function formatOutput(ctx) {
 }
 
 // scripts/statusline.ts
-var CONFIG_PATH = join6(homedir6(), ".claude", "claude-dashboard.local.json");
+var CONFIG_PATH = join8(homedir4(), ".claude", "claude-dashboard.local.json");
 var configCache = null;
 async function readStdin() {
   try {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1611,7 +1611,7 @@ var configCountsWidget = {
       return null;
     }
     const addedDirs = ctx.stdin.workspace?.added_dirs?.length ?? 0;
-    if (configCountsCache?.projectDir === currentDir && Date.now() - configCountsCache.timestamp < CONFIG_CACHE_TTL_MS) {
+    if (configCountsCache?.projectDir === currentDir && configCountsCache.claudeJsonPath === getClaudeJsonPath() && Date.now() - configCountsCache.timestamp < CONFIG_CACHE_TTL_MS) {
       if (!configCountsCache.data && addedDirs === 0)
         return null;
       const fsData2 = configCountsCache.data ?? EMPTY_FS_COUNTS;
@@ -1626,7 +1626,12 @@ var configCountsWidget = {
       countFiles(join4(claudeDir, "hooks"))
     ]);
     const fsData = claudeMd === 0 && agentsMd === 0 && rules === 0 && mcps === 0 && hooks === 0 ? null : { claudeMd, agentsMd, rules, mcps, hooks };
-    configCountsCache = { projectDir: currentDir, data: fsData, timestamp: Date.now() };
+    configCountsCache = {
+      projectDir: currentDir,
+      claudeJsonPath: getClaudeJsonPath(),
+      data: fsData,
+      timestamp: Date.now()
+    };
     if (!fsData && addedDirs === 0)
       return null;
     return { ...fsData ?? EMPTY_FS_COUNTS, addedDirs };

--- a/scripts/__tests__/commands-config-dir.test.ts
+++ b/scripts/__tests__/commands-config-dir.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Verifies the executable snippets shipped inside the slash-command docs
+ * (commands/setup.md, update.md, check-usage.md, setup-alias.md) and the
+ * README manual-install line honor CLAUDE_CONFIG_DIR. Snippets are extracted
+ * from the shipped markdown, so doc edits that break multi-account routing
+ * fail here. Markdown files sit outside the @tested/@covers marker system;
+ * this file references them by path instead.
+ * @handbook 8.1-test-structure
+ * @handbook 8.5-doc-snippet-tests
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, realpathSync, rmSync, existsSync } from 'fs';
+import path from 'path';
+import os from 'os';
+
+const REPO = path.resolve(__dirname, '..', '..');
+const read = (rel: string) => readFileSync(path.join(REPO, rel), 'utf-8');
+const line = (rel: string, re: RegExp) => {
+  const m = read(rel).match(re);
+  if (!m) throw new Error(`snippet not found in ${rel}: ${re}`);
+  return m[0];
+};
+
+// bash one-liners can't run on Windows runners
+describe.skipIf(process.platform === 'win32')('commands/*.md CLAUDE_CONFIG_DIR snippets', () => {
+  let SB: string;
+  let HOME: string;
+  let ALT: string;
+
+  const run = (cmd: string, env: Record<string, string> = {}) =>
+    execFileSync('bash', ['-c', cmd], {
+      // Deliberately minimal env (à la `env -i`): CLAUDE_CONFIG_DIR only present when a test sets it
+      env: { PATH: process.env.PATH ?? '', HOME, ...env },
+      encoding: 'utf-8',
+    });
+
+  const settingsCommand = (dir: string) =>
+    JSON.parse(readFileSync(path.join(dir, 'settings.json'), 'utf-8')).statusLine.command as string;
+
+  beforeAll(() => {
+    // realpath: node resolves /var -> /private/var on macOS; keep asserts canonical
+    SB = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'claude-dashboard-cmd-test-')));
+    HOME = path.join(SB, 'home');
+    ALT = path.join(SB, 'alt');
+    for (const [base, version] of [
+      [path.join(HOME, '.claude'), '1.29.0'],
+      [path.join(HOME, '.claude'), '1.30.0'],
+      [ALT, '2.0.0'],
+    ] as const) {
+      const dist = path.join(base, 'plugins/cache/claude-dashboard/claude-dashboard', version, 'dist');
+      mkdirSync(dist, { recursive: true });
+      writeFileSync(path.join(dist, 'index.js'), 'console.log(__filename)\n');
+      writeFileSync(path.join(dist, 'check-usage.js'), 'console.log(__filename)\n');
+    }
+  });
+
+  afterAll(() => {
+    rmSync(SB, { recursive: true, force: true });
+  });
+
+  const SETUP = () => line('commands/setup.md', /^CFGDIR=.*$/m);
+  const UPDATE = () =>
+    [
+      line('commands/update.md', /^CFGDIR=.*$/m),
+      line('commands/update.md', /^LATEST_VERSION=.*$/m),
+      line('commands/update.md', /^NEWCMD=.*$/m),
+    ].join('\n');
+
+  it('setup writes the default config dir when CLAUDE_CONFIG_DIR is unset', () => {
+    run(SETUP());
+    expect(settingsCommand(path.join(HOME, '.claude'))).toContain('1.30.0/dist/index.js');
+  });
+
+  it('setup writes the relocated config dir without touching the default one', () => {
+    run(SETUP(), { CLAUDE_CONFIG_DIR: ALT });
+    expect(settingsCommand(ALT)).toContain('2.0.0/dist/index.js');
+    expect(settingsCommand(path.join(HOME, '.claude'))).toContain('1.30.0/dist/index.js');
+  });
+
+  it('setup treats an empty CLAUDE_CONFIG_DIR as unset', () => {
+    rmSync(path.join(HOME, '.claude', 'settings.json'));
+    run(SETUP(), { CLAUDE_CONFIG_DIR: '' });
+    expect(settingsCommand(path.join(HOME, '.claude'))).toContain('1.30.0/dist/index.js');
+  });
+
+  it('update rewrites the command in the config dir the env selects', () => {
+    run(UPDATE(), { CLAUDE_CONFIG_DIR: ALT });
+    expect(settingsCommand(ALT)).toBe(
+      `node ${ALT}/plugins/cache/claude-dashboard/claude-dashboard/2.0.0/dist/index.js`
+    );
+    run(UPDATE());
+    expect(settingsCommand(path.join(HOME, '.claude'))).toContain('1.30.0/dist/index.js');
+  });
+
+  it('check-usage resolves the script inside the selected config dir', () => {
+    const cmd = line('commands/check-usage.md', /^node "\$\(ls -d.*$/m).replace(/ \$ARGUMENTS$/, '');
+    expect(run(cmd).trim()).toBe(
+      path.join(HOME, '.claude', 'plugins/cache/claude-dashboard/claude-dashboard/1.30.0/dist/check-usage.js')
+    );
+    expect(run(cmd, { CLAUDE_CONFIG_DIR: ALT }).trim()).toBe(
+      path.join(ALT, 'plugins/cache/claude-dashboard/claude-dashboard/2.0.0/dist/check-usage.js')
+    );
+  });
+
+  it('check-ai alias resolves per invocation, following env switches', () => {
+    const fn = line('commands/setup-alias.md', /^check-ai\(\) \{\n[\s\S]*?^\}$/m);
+    expect(run(`${fn}\ncheck-ai`).trim()).toContain('1.30.0/dist/check-usage.js');
+    expect(run(`${fn}\ncheck-ai`, { CLAUDE_CONFIG_DIR: ALT }).trim()).toContain('2.0.0/dist/check-usage.js');
+  });
+
+  it('README manual-install clone lands in the selected config dir', () => {
+    const bare = path.join(SB, 'fixture.git');
+    run(`git init -q --bare "${bare}" && git clone -q "${bare}" "${SB}/seed" && cd "${SB}/seed" && git -c user.email=t@t -c user.name=t commit -q --allow-empty -m x && git push -q origin HEAD`);
+    const clone = line('README.md', /^git clone https.*$/m).replace(
+      'https://github.com/uppinote20/claude-dashboard.git',
+      bare
+    );
+    run(clone);
+    expect(existsSync(path.join(HOME, '.claude/plugins/claude-dashboard/.git'))).toBe(true);
+    run(clone, { CLAUDE_CONFIG_DIR: ALT });
+    expect(existsSync(path.join(ALT, 'plugins/claude-dashboard/.git'))).toBe(true);
+  });
+});

--- a/scripts/__tests__/commands-config-dir.test.ts
+++ b/scripts/__tests__/commands-config-dir.test.ts
@@ -16,10 +16,21 @@ import os from 'os';
 
 const REPO = path.resolve(__dirname, '..', '..');
 const read = (rel: string) => readFileSync(path.join(REPO, rel), 'utf-8');
+/**
+ * Extract a snippet by anchor regex. All matches in the file must be
+ * byte-identical: docs may legitimately repeat a snippet (setup-alias.md keeps
+ * a preview block plus a heredoc copy), but divergent matches mean the anchor
+ * grabbed the wrong line or the copies drifted — fail loudly instead of
+ * silently testing whichever came first.
+ */
 const line = (rel: string, re: RegExp) => {
-  const m = read(rel).match(re);
-  if (!m) throw new Error(`snippet not found in ${rel}: ${re}`);
-  return m[0];
+  const flags = re.flags.includes('g') ? re.flags : re.flags + 'g';
+  const matches = [...read(rel).matchAll(new RegExp(re.source, flags))].map((m) => m[0]);
+  if (matches.length === 0) throw new Error(`snippet not found in ${rel}: ${re}`);
+  if (new Set(matches).size > 1) {
+    throw new Error(`ambiguous snippet anchor in ${rel}: ${re} matched ${matches.length} divergent copies`);
+  }
+  return matches[0];
 };
 
 // bash one-liners can't run on Windows runners

--- a/scripts/__tests__/config-counts.test.ts
+++ b/scripts/__tests__/config-counts.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @handbook 8.1-test-structure
+ * @covers scripts/widgets/config-counts.ts
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdir, writeFile, rm } from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import type { WidgetContext } from '../types.js';
+
+const TEST_DIR = path.join(os.tmpdir(), 'claude-dashboard-configcounts-test-' + process.pid);
+const PROJECT_DIR = path.join(TEST_DIR, 'proj');
+const DEFAULT_CLAUDE_JSON = path.join(TEST_DIR, '.claude.json');
+
+// Second account's config dir — .claude.json moves *inside* it
+const ALT_CONFIG_DIR = path.join(TEST_DIR, '.claude-max');
+const ALT_CLAUDE_JSON = path.join(ALT_CONFIG_DIR, '.claude.json');
+
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return { ...actual, homedir: () => TEST_DIR };
+});
+
+const ctx = { stdin: { workspace: { current_dir: PROJECT_DIR } } } as unknown as WidgetContext;
+
+describe('configCounts (getData)', () => {
+  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  const originalHome = process.env.HOME;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    delete process.env.CLAUDE_CONFIG_DIR;
+    // countMcps' XDG path derives from HOME; pin it to the sandbox
+    process.env.HOME = TEST_DIR;
+    await mkdir(PROJECT_DIR, { recursive: true });
+    await mkdir(ALT_CONFIG_DIR, { recursive: true });
+    await writeFile(DEFAULT_CLAUDE_JSON, JSON.stringify({ mcpServers: { a: {}, b: {} } }));
+    await writeFile(ALT_CLAUDE_JSON, JSON.stringify({ mcpServers: { x: {} } }));
+  });
+
+  afterEach(async () => {
+    if (originalConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    try {
+      await rm(TEST_DIR, { recursive: true, force: true });
+    } catch { /* ignore */ }
+  });
+
+  it('should count global MCP servers from the default .claude.json', async () => {
+    const { configCountsWidget } = await import('../widgets/config-counts.js');
+
+    expect((await configCountsWidget.getData(ctx))?.mcps).toBe(2);
+  });
+
+  it('should not serve one account\'s cached MCP count for the other within the TTL', async () => {
+    const { configCountsWidget } = await import('../widgets/config-counts.js');
+
+    expect((await configCountsWidget.getData(ctx))?.mcps).toBe(2);
+
+    // Same process, same projectDir, still inside the 30s TTL — only the config dir switches
+    process.env.CLAUDE_CONFIG_DIR = ALT_CONFIG_DIR;
+    expect((await configCountsWidget.getData(ctx))?.mcps).toBe(1);
+  });
+});

--- a/scripts/__tests__/config-dir.test.ts
+++ b/scripts/__tests__/config-dir.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @handbook 8.1-test-structure
+ * @covers scripts/utils/config-dir.ts
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'path';
+import os from 'os';
+
+const TEST_HOME = path.join(os.tmpdir(), 'claude-dashboard-configdir-test-' + process.pid);
+
+// Mock homedir so the default branch is assertable without touching the real home
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return { ...actual, homedir: () => TEST_HOME };
+});
+
+describe('config-dir', () => {
+  const originalEnv = process.env.CLAUDE_CONFIG_DIR;
+
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.CLAUDE_CONFIG_DIR;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = originalEnv;
+  });
+
+  describe('getClaudeConfigDir', () => {
+    it('should default to ~/.claude when CLAUDE_CONFIG_DIR is unset', async () => {
+      const { getClaudeConfigDir } = await import('../utils/config-dir.js');
+
+      expect(getClaudeConfigDir()).toBe(path.join(TEST_HOME, '.claude'));
+    });
+
+    it('should use CLAUDE_CONFIG_DIR when set', async () => {
+      // Strict replacement, not a search path: Claude Code itself reports
+      // "not logged in" rather than falling back to ~/.claude.
+      process.env.CLAUDE_CONFIG_DIR = '/custom/claude-max';
+
+      const { getClaudeConfigDir } = await import('../utils/config-dir.js');
+
+      expect(getClaudeConfigDir()).toBe('/custom/claude-max');
+    });
+
+    it('should read the env var at call time, not import time', async () => {
+      const { getClaudeConfigDir } = await import('../utils/config-dir.js');
+      expect(getClaudeConfigDir()).toBe(path.join(TEST_HOME, '.claude'));
+
+      process.env.CLAUDE_CONFIG_DIR = '/switched-mid-process';
+
+      expect(getClaudeConfigDir()).toBe('/switched-mid-process');
+    });
+
+    it('should ignore an empty CLAUDE_CONFIG_DIR instead of building a relative path', async () => {
+      process.env.CLAUDE_CONFIG_DIR = '';
+
+      const { getClaudeConfigDir } = await import('../utils/config-dir.js');
+
+      expect(getClaudeConfigDir()).toBe(path.join(TEST_HOME, '.claude'));
+      expect(path.isAbsolute(getClaudeConfigDir())).toBe(true);
+    });
+  });
+
+  describe('getClaudeJsonPath', () => {
+    it('should default to $HOME/.claude.json (beside ~/.claude, not inside it)', async () => {
+      const { getClaudeJsonPath } = await import('../utils/config-dir.js');
+
+      expect(getClaudeJsonPath()).toBe(path.join(TEST_HOME, '.claude.json'));
+      // The asymmetry that makes this a separate helper: NOT ~/.claude/.claude.json
+      expect(getClaudeJsonPath()).not.toBe(path.join(TEST_HOME, '.claude', '.claude.json'));
+    });
+
+    it('should move inside CLAUDE_CONFIG_DIR when set', async () => {
+      process.env.CLAUDE_CONFIG_DIR = '/custom/claude-max';
+
+      const { getClaudeJsonPath } = await import('../utils/config-dir.js');
+
+      expect(getClaudeJsonPath()).toBe(path.join('/custom/claude-max', '.claude.json'));
+    });
+  });
+});

--- a/scripts/__tests__/credentials.test.ts
+++ b/scripts/__tests__/credentials.test.ts
@@ -11,6 +11,10 @@ const TEST_DIR = path.join(os.tmpdir(), 'claude-dashboard-cred-test-' + process.
 const CRED_DIR = path.join(TEST_DIR, '.claude');
 const CRED_FILE = path.join(CRED_DIR, '.credentials.json');
 
+// Second account's config dir, as relocated via CLAUDE_CONFIG_DIR
+const ALT_CONFIG_DIR = path.join(TEST_DIR, '.claude-max');
+const ALT_CRED_FILE = path.join(ALT_CONFIG_DIR, '.credentials.json');
+
 // Mock homedir to use test directory
 vi.mock('os', async (importOriginal) => {
   const actual = await importOriginal<typeof import('os')>();
@@ -26,12 +30,18 @@ vi.mock('child_process', () => ({
 }));
 
 describe('credentials', () => {
+  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+
   beforeEach(async () => {
     vi.resetModules();
+    // Keep a contributor's own CLAUDE_CONFIG_DIR from leaking into these tests
+    delete process.env.CLAUDE_CONFIG_DIR;
     await mkdir(CRED_DIR, { recursive: true });
   });
 
   afterEach(async () => {
+    if (originalConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
     try {
       await rm(TEST_DIR, { recursive: true, force: true });
     } catch { /* ignore */ }
@@ -84,6 +94,34 @@ describe('credentials', () => {
 
       const second = await getCredentials();
       expect(second).toBe('token-1');
+    });
+  });
+
+  // Issue #81: two accounts side by side — the default ~/.claude holds one
+  // account while CLAUDE_CONFIG_DIR points the running session at the other.
+  describe('CLAUDE_CONFIG_DIR (multi-account)', () => {
+    beforeEach(async () => {
+      await mkdir(ALT_CONFIG_DIR, { recursive: true });
+      await writeFile(CRED_FILE, JSON.stringify({
+        claudeAiOauth: { accessToken: 'default-account-token' },
+      }));
+      await writeFile(ALT_CRED_FILE, JSON.stringify({
+        claudeAiOauth: { accessToken: 'relocated-account-token' },
+      }));
+    });
+
+    it('should read the relocated account token when CLAUDE_CONFIG_DIR is set', async () => {
+      process.env.CLAUDE_CONFIG_DIR = ALT_CONFIG_DIR;
+
+      const { getCredentials } = await import('../utils/credentials.js');
+
+      expect(await getCredentials()).toBe('relocated-account-token');
+    });
+
+    it('should read the default account token when CLAUDE_CONFIG_DIR is unset', async () => {
+      const { getCredentials } = await import('../utils/credentials.js');
+
+      expect(await getCredentials()).toBe('default-account-token');
     });
   });
 });

--- a/scripts/__tests__/credentials.test.ts
+++ b/scripts/__tests__/credentials.test.ts
@@ -3,7 +3,7 @@
  * @covers scripts/utils/credentials.ts
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdir, writeFile, rm } from 'fs/promises';
+import { mkdir, writeFile, rm, utimes } from 'fs/promises';
 import path from 'path';
 import os from 'os';
 
@@ -121,6 +121,22 @@ describe('credentials', () => {
     it('should read the default account token when CLAUDE_CONFIG_DIR is unset', async () => {
       const { getCredentials } = await import('../utils/credentials.js');
 
+      expect(await getCredentials()).toBe('default-account-token');
+    });
+
+    it('should not serve one account\'s cached token for the other when mtimes collide', async () => {
+      // Force identical mtimes so mtime alone cannot distinguish the two files
+      const sharedMtime = new Date('2024-01-01T00:00:00Z');
+      await utimes(CRED_FILE, sharedMtime, sharedMtime);
+      await utimes(ALT_CRED_FILE, sharedMtime, sharedMtime);
+
+      process.env.CLAUDE_CONFIG_DIR = ALT_CONFIG_DIR;
+      const { getCredentials } = await import('../utils/credentials.js');
+      expect(await getCredentials()).toBe('relocated-account-token');
+
+      // Same process, back to the default account: the relocated token
+      // must not leak through the mtime-keyed cache
+      delete process.env.CLAUDE_CONFIG_DIR;
       expect(await getCredentials()).toBe('default-account-token');
     });
   });

--- a/scripts/__tests__/history-parser.test.ts
+++ b/scripts/__tests__/history-parser.test.ts
@@ -17,12 +17,18 @@ vi.mock('os', async (importOriginal) => {
 });
 
 describe('history-parser', () => {
+  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+
   beforeEach(async () => {
     vi.resetModules();
+    // Keep a contributor's own CLAUDE_CONFIG_DIR from redirecting these tests
+    delete process.env.CLAUDE_CONFIG_DIR;
     await mkdir(CLAUDE_DIR, { recursive: true });
   });
 
   afterEach(async () => {
+    if (originalConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
     try {
       await rm(TEST_DIR, { recursive: true, force: true });
     } catch { /* ignore */ }
@@ -136,6 +142,30 @@ describe('history-parser', () => {
       // Second call should hit cache (file unchanged)
       const second = await getLastUserPrompt('sess-1');
       expect(second?.text).toBe('Cached prompt');
+    });
+  });
+
+  // Issue #81 follow-up: the cache must be keyed by path, not just file size,
+  // so switching CLAUDE_CONFIG_DIR mid-process cannot serve stale prompts.
+  describe('CLAUDE_CONFIG_DIR (multi-account)', () => {
+    const ALT_CLAUDE_DIR = path.join(TEST_DIR, '.claude-max');
+    const ALT_HISTORY_FILE = path.join(ALT_CLAUDE_DIR, 'history.jsonl');
+
+    it('should not serve one account\'s cached prompt for the other when file sizes collide', async () => {
+      await mkdir(ALT_CLAUDE_DIR, { recursive: true });
+      // Same byte length so size alone cannot distinguish the two files
+      const defaultEntry = JSON.stringify({ sessionId: 'sess-1', display: 'From default dir', timestamp: '2024-01-01T10:00:00Z' });
+      const relocatedEntry = JSON.stringify({ sessionId: 'sess-1', display: 'From claude-max ', timestamp: '2024-01-01T10:00:00Z' });
+      expect(relocatedEntry.length).toBe(defaultEntry.length);
+      await writeFile(HISTORY_FILE, defaultEntry);
+      await writeFile(ALT_HISTORY_FILE, relocatedEntry);
+
+      const { getLastUserPrompt } = await import('../utils/history-parser.js');
+
+      expect((await getLastUserPrompt('sess-1'))?.text).toBe('From default dir');
+
+      process.env.CLAUDE_CONFIG_DIR = ALT_CLAUDE_DIR;
+      expect((await getLastUserPrompt('sess-1'))?.text).toBe('From claude-max');
     });
   });
 });

--- a/scripts/__tests__/model-settings.test.ts
+++ b/scripts/__tests__/model-settings.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @handbook 8.1-test-structure
+ * @covers scripts/widgets/model.ts
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdir, writeFile, rm, utimes } from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import type { WidgetContext } from '../types.js';
+
+const TEST_DIR = path.join(os.tmpdir(), 'claude-dashboard-model-test-' + process.pid);
+const SETTINGS_FILE = path.join(TEST_DIR, '.claude', 'settings.json');
+
+// Second account's config dir, as relocated via CLAUDE_CONFIG_DIR
+const ALT_CONFIG_DIR = path.join(TEST_DIR, '.claude-max');
+const ALT_SETTINGS_FILE = path.join(ALT_CONFIG_DIR, 'settings.json');
+
+// Mock homedir to use test directory
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return { ...actual, homedir: () => TEST_DIR };
+});
+
+const ctx = { stdin: { model: { id: 'claude-fable-5' } } } as unknown as WidgetContext;
+
+describe('model settings (getData)', () => {
+  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  const originalEnvEffort = process.env.CLAUDE_CODE_EFFORT_LEVEL;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    // Keep a contributor's own env from leaking into these tests
+    delete process.env.CLAUDE_CONFIG_DIR;
+    delete process.env.CLAUDE_CODE_EFFORT_LEVEL;
+    await mkdir(path.dirname(SETTINGS_FILE), { recursive: true });
+    await mkdir(ALT_CONFIG_DIR, { recursive: true });
+  });
+
+  afterEach(async () => {
+    if (originalConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
+    if (originalEnvEffort === undefined) delete process.env.CLAUDE_CODE_EFFORT_LEVEL;
+    else process.env.CLAUDE_CODE_EFFORT_LEVEL = originalEnvEffort;
+    try {
+      await rm(TEST_DIR, { recursive: true, force: true });
+    } catch { /* ignore */ }
+  });
+
+  it('should read effortLevel from the config dir settings.json', async () => {
+    await writeFile(SETTINGS_FILE, JSON.stringify({ effortLevel: 'low' }));
+
+    const { modelWidget } = await import('../widgets/model.js');
+    const data = await modelWidget.getData(ctx);
+
+    expect(data?.effortLevel).toBe('low');
+  });
+
+  it('should not serve one account\'s cached effort for the other when mtimes collide', async () => {
+    await writeFile(SETTINGS_FILE, JSON.stringify({ effortLevel: 'low' }));
+    await writeFile(ALT_SETTINGS_FILE, JSON.stringify({ effortLevel: 'max' }));
+    // Force identical mtimes so mtime alone cannot distinguish the two files
+    const sharedMtime = new Date('2024-01-01T00:00:00Z');
+    await utimes(SETTINGS_FILE, sharedMtime, sharedMtime);
+    await utimes(ALT_SETTINGS_FILE, sharedMtime, sharedMtime);
+
+    const { modelWidget } = await import('../widgets/model.js');
+
+    expect((await modelWidget.getData(ctx))?.effortLevel).toBe('low');
+
+    // Same process, config dir switches to the relocated account
+    process.env.CLAUDE_CONFIG_DIR = ALT_CONFIG_DIR;
+    expect((await modelWidget.getData(ctx))?.effortLevel).toBe('max');
+  });
+});

--- a/scripts/statusline.ts
+++ b/scripts/statusline.ts
@@ -20,6 +20,10 @@ import { fetchUsageLimits } from './utils/api-client.js';
 import { getTranslations } from './utils/i18n.js';
 import { formatOutput } from './widgets/index.js';
 
+// The plugin's own config, not one of Claude Code's files, so it deliberately
+// stays on homedir() rather than following CLAUDE_CONFIG_DIR: setup writes it to
+// ~/.claude unconditionally, and relocating the read would silently reset an
+// existing multi-account user's dashboard to DEFAULT_CONFIG.
 const CONFIG_PATH = join(homedir(), '.claude', 'claude-dashboard.local.json');
 
 /**

--- a/scripts/utils/config-dir.ts
+++ b/scripts/utils/config-dir.ts
@@ -1,0 +1,34 @@
+/**
+ * Claude Code configuration directory resolution
+ * @handbook 3.3-widget-data-sources
+ * @tested scripts/__tests__/config-dir.test.ts
+ */
+import { join } from 'path';
+import { homedir } from 'os';
+
+/**
+ * Resolve Claude Code's configuration directory.
+ *
+ * When CLAUDE_CONFIG_DIR is set, Claude Code reads `.credentials.json`,
+ * `settings.json`, and `history.jsonl` from there and does not fall back to
+ * ~/.claude. Mirror that so the statusline reports the account rendering it
+ * rather than whichever account happens to own ~/.claude.
+ *
+ * `||` rather than `??`: an empty CLAUDE_CONFIG_DIR must not resolve to a
+ * CWD-relative path.
+ */
+export function getClaudeConfigDir(): string {
+  return process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
+}
+
+/**
+ * Resolve the global `.claude.json` (holds top-level MCP servers).
+ *
+ * Its default lives beside ~/.claude at `$HOME/.claude.json`, but with
+ * CLAUDE_CONFIG_DIR set it moves *inside* that directory — so it can't reuse
+ * getClaudeConfigDir(), which would otherwise point at ~/.claude/.claude.json.
+ */
+export function getClaudeJsonPath(): string {
+  const configDir = process.env.CLAUDE_CONFIG_DIR;
+  return configDir ? join(configDir, '.claude.json') : join(homedir(), '.claude.json');
+}

--- a/scripts/utils/config-dir.ts
+++ b/scripts/utils/config-dir.ts
@@ -7,6 +7,14 @@ import { join } from 'path';
 import { homedir } from 'os';
 
 /**
+ * Defaults are module-level constants: the home directory cannot change
+ * mid-process, and these are on the per-render hot path. Only the
+ * CLAUDE_CONFIG_DIR env var must be read at call time.
+ */
+const DEFAULT_CONFIG_DIR = join(homedir(), '.claude');
+const DEFAULT_CLAUDE_JSON_PATH = join(homedir(), '.claude.json');
+
+/**
  * Resolve Claude Code's configuration directory.
  *
  * When CLAUDE_CONFIG_DIR is set, Claude Code reads `.credentials.json`,
@@ -18,7 +26,7 @@ import { homedir } from 'os';
  * CWD-relative path.
  */
 export function getClaudeConfigDir(): string {
-  return process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
+  return process.env.CLAUDE_CONFIG_DIR || DEFAULT_CONFIG_DIR;
 }
 
 /**
@@ -30,5 +38,5 @@ export function getClaudeConfigDir(): string {
  */
 export function getClaudeJsonPath(): string {
   const configDir = process.env.CLAUDE_CONFIG_DIR;
-  return configDir ? join(configDir, '.claude.json') : join(homedir(), '.claude.json');
+  return configDir ? join(configDir, '.claude.json') : DEFAULT_CLAUDE_JSON_PATH;
 }

--- a/scripts/utils/credentials.ts
+++ b/scripts/utils/credentials.ts
@@ -21,11 +21,14 @@ const KEYCHAIN_CACHE_TTL_MS = 10_000;
 const KEYCHAIN_BACKOFF_MS = 60_000;
 
 /**
- * Cached credentials with mtime-based invalidation for file
- * or TTL-based invalidation for keychain
+ * Cached credentials with path+mtime-based invalidation for file
+ * or TTL-based invalidation for keychain.
+ * The path is part of the key because CLAUDE_CONFIG_DIR can switch
+ * mid-process and mtime alone can collide across directories.
  */
 let credentialsCache: {
   token: string | null;
+  path?: string; // For file-based cache
   mtime?: number; // For file-based cache
   timestamp?: number; // For keychain-based cache
 } | null = null;
@@ -122,8 +125,8 @@ async function getCredentialsFromFile(): Promise<string | null> {
     const fileStat = await stat(credPath);
     const mtime = fileStat.mtimeMs;
 
-    // Return cached if mtime matches
-    if (credentialsCache?.mtime === mtime) {
+    // Return cached if both path and mtime match
+    if (credentialsCache?.path === credPath && credentialsCache.mtime === mtime) {
       return credentialsCache.token;
     }
 
@@ -132,7 +135,7 @@ async function getCredentialsFromFile(): Promise<string | null> {
     const token = creds?.claudeAiOauth?.accessToken ?? null;
 
     // Cache result
-    credentialsCache = { token, mtime };
+    credentialsCache = { token, path: credPath, mtime };
     return token;
   } catch {
     return null;

--- a/scripts/utils/credentials.ts
+++ b/scripts/utils/credentials.ts
@@ -6,7 +6,7 @@
 import { execFile } from 'child_process';
 import { readFile, stat } from 'fs/promises';
 import { join } from 'path';
-import { homedir } from 'os';
+import { getClaudeConfigDir } from './config-dir.js';
 
 /**
  * Cache TTL for keychain credentials (10 seconds)
@@ -42,7 +42,7 @@ let keychainBackoffAt: number | null = null;
  * Get OAuth access token from Claude Code credentials
  *
  * On macOS: Reads from Keychain (TTL-based cache)
- * On Linux/Windows: Reads from ~/.claude/.credentials.json (mtime-based cache)
+ * On Linux/Windows: Reads from the config dir's .credentials.json (mtime-based cache)
  *
  * @returns Access token or null if not found
  */
@@ -112,11 +112,11 @@ async function getCredentialsFromKeychain(): Promise<string | null> {
 }
 
 /**
- * Get credentials from file (~/.claude/.credentials.json) with mtime-based cache
+ * Get credentials from the config dir's .credentials.json with mtime-based cache
  */
 async function getCredentialsFromFile(): Promise<string | null> {
   try {
-    const credPath = join(homedir(), '.claude', '.credentials.json');
+    const credPath = join(getClaudeConfigDir(), '.credentials.json');
 
     // Check mtime for cache invalidation
     const fileStat = await stat(credPath);

--- a/scripts/utils/history-parser.ts
+++ b/scripts/utils/history-parser.ts
@@ -31,6 +31,9 @@ function resolvePastedText(
 }
 
 let historyCache: {
+  /** Resolved history.jsonl path — CLAUDE_CONFIG_DIR can switch mid-process
+   * and file size alone can collide across directories */
+  path: string;
   fileSize: number;
   /** Cached results keyed by sessionId */
   results: Map<string, LastPromptData | null>;
@@ -48,15 +51,17 @@ export async function getLastUserPrompt(
     const historyPath = join(getClaudeConfigDir(), 'history.jsonl');
     const fileStat = await stat(historyPath);
 
-    // Return cached result if file hasn't grown
-    if (historyCache && historyCache.fileSize === fileStat.size) {
+    // Return cached result if it is the same file at the same size
+    if (
+      historyCache &&
+      historyCache.path === historyPath &&
+      historyCache.fileSize === fileStat.size
+    ) {
       const cached = historyCache.results.get(sessionId);
       if (cached !== undefined) return cached;
-    }
-
-    // File changed — invalidate all cached results
-    if (!historyCache || historyCache.fileSize !== fileStat.size) {
-      historyCache = { fileSize: fileStat.size, results: new Map() };
+    } else {
+      // File changed or config dir switched — invalidate all cached results
+      historyCache = { path: historyPath, fileSize: fileStat.size, results: new Map() };
     }
 
     const size = Math.min(CHUNK, fileStat.size);

--- a/scripts/utils/history-parser.ts
+++ b/scripts/utils/history-parser.ts
@@ -1,5 +1,5 @@
 /**
- * History parser - reads ~/.claude/history.jsonl for user prompt data
+ * History parser - reads the config dir's history.jsonl for user prompt data
  * Unlike transcript.jsonl, history.jsonl only contains actual user input
  * via the `display` field, excluding skill/command expansions.
  *
@@ -9,10 +9,10 @@
  */
 
 import { open, stat } from 'fs/promises';
-import { homedir } from 'os';
+import { join } from 'path';
+import { getClaudeConfigDir } from './config-dir.js';
 import type { LastPromptData } from '../types.js';
 
-const HISTORY_PATH = `${homedir()}/.claude/history.jsonl`;
 const CHUNK = 16 * 1024;
 
 /**
@@ -37,7 +37,7 @@ let historyCache: {
 } | null = null;
 
 /**
- * Get the last user prompt from ~/.claude/history.jsonl.
+ * Get the last user prompt from the config dir's history.jsonl.
  * Tail-reads the last 16KB and reverse-scans for the current session's
  * most recent entry. Results are cached until file size changes.
  */
@@ -45,7 +45,8 @@ export async function getLastUserPrompt(
   sessionId: string
 ): Promise<LastPromptData | null> {
   try {
-    const fileStat = await stat(HISTORY_PATH);
+    const historyPath = join(getClaudeConfigDir(), 'history.jsonl');
+    const fileStat = await stat(historyPath);
 
     // Return cached result if file hasn't grown
     if (historyCache && historyCache.fileSize === fileStat.size) {
@@ -59,7 +60,7 @@ export async function getLastUserPrompt(
     }
 
     const size = Math.min(CHUNK, fileStat.size);
-    const fd = await open(HISTORY_PATH, 'r');
+    const fd = await open(historyPath, 'r');
     try {
       const buffer = Buffer.alloc(size);
       await fd.read(buffer, 0, size, fileStat.size - size);

--- a/scripts/widgets/config-counts.ts
+++ b/scripts/widgets/config-counts.ts
@@ -2,6 +2,7 @@
  * Config counts widget - displays counts of CLAUDE.md, rules, MCPs, hooks
  * @handbook 3.3-widget-data-sources
  * @tested scripts/__tests__/widgets.test.ts
+ * @tested scripts/__tests__/config-counts.test.ts
  */
 
 import { readdir, readFile, stat } from 'fs/promises';
@@ -22,8 +23,14 @@ type FsCountsData = Omit<ConfigCountsData, 'addedDirs'>;
 
 const EMPTY_FS_COUNTS: FsCountsData = { claudeMd: 0, agentsMd: 0, rules: 0, mcps: 0, hooks: 0 };
 
+/**
+ * claudeJsonPath is part of the cache key because countMcps() reads the
+ * CLAUDE_CONFIG_DIR-dependent .claude.json — an env switch within the TTL
+ * must not serve the previous account's counts.
+ */
 let configCountsCache: {
   projectDir: string;
+  claudeJsonPath: string;
   data: FsCountsData | null;
   timestamp: number;
 } | null = null;
@@ -122,6 +129,7 @@ export const configCountsWidget: Widget<ConfigCountsData> = {
     // Check TTL-based cache for filesystem counts
     if (
       configCountsCache?.projectDir === currentDir &&
+      configCountsCache.claudeJsonPath === getClaudeJsonPath() &&
       Date.now() - configCountsCache.timestamp < CONFIG_CACHE_TTL_MS
     ) {
       if (!configCountsCache.data && addedDirs === 0) return null;
@@ -146,7 +154,12 @@ export const configCountsWidget: Widget<ConfigCountsData> = {
         ? null
         : { claudeMd, agentsMd, rules, mcps, hooks };
 
-    configCountsCache = { projectDir: currentDir, data: fsData, timestamp: Date.now() };
+    configCountsCache = {
+      projectDir: currentDir,
+      claudeJsonPath: getClaudeJsonPath(),
+      data: fsData,
+      timestamp: Date.now(),
+    };
 
     if (!fsData && addedDirs === 0) return null;
     return { ...(fsData ?? EMPTY_FS_COUNTS), addedDirs };

--- a/scripts/widgets/config-counts.ts
+++ b/scripts/widgets/config-counts.ts
@@ -9,6 +9,7 @@ import { join } from 'path';
 import type { Widget } from './base.js';
 import type { WidgetContext, ConfigCountsData } from '../types.js';
 import { colorize, getTheme } from '../utils/colors.js';
+import { getClaudeJsonPath } from '../utils/config-dir.js';
 
 /**
  * Cache TTL for config counts (30 seconds)
@@ -85,7 +86,8 @@ async function countMcps(projectDir: string): Promise<number> {
 
   const mcpPaths = [
     { path: join(projectDir, '.claude', 'mcp.json'), key: 'mcpServers' },
-    { path: join(homeDir, '.claude.json'), key: 'mcpServers' },
+    // Global MCP config follows CLAUDE_CONFIG_DIR; the XDG path below does not.
+    { path: getClaudeJsonPath(), key: 'mcpServers' },
     { path: join(homeDir, '.config', 'claude-code', 'mcp.json'), key: 'mcpServers' },
   ];
 

--- a/scripts/widgets/last-prompt.ts
+++ b/scripts/widgets/last-prompt.ts
@@ -1,6 +1,6 @@
 /**
  * Last Prompt widget - displays the most recent user prompt in the session
- * Data source: ~/.claude/history.jsonl (contains only actual user input)
+ * Data source: history.jsonl in the config dir (contains only actual user input)
  * @handbook 3.3-widget-data-sources
  * @tested scripts/__tests__/widgets.test.ts
  */

--- a/scripts/widgets/model.ts
+++ b/scripts/widgets/model.ts
@@ -10,7 +10,7 @@
 
 import { readFile, stat } from 'fs/promises';
 import { join } from 'path';
-import { homedir } from 'os';
+import { getClaudeConfigDir } from '../utils/config-dir.js';
 import type { Widget } from './base.js';
 import type { WidgetContext, ModelData, EffortLevel } from '../types.js';
 import { RESET, getTheme } from '../utils/colors.js';
@@ -66,7 +66,7 @@ let settingsCache: { rawEffort: unknown; fastMode: boolean; mtime: number } | nu
 
 async function getModelSettings(modelId: string): Promise<ModelSettings> {
   const defaultEffort = getDefaultEffort(modelId);
-  const settingsPath = join(homedir(), '.claude', 'settings.json');
+  const settingsPath = join(getClaudeConfigDir(), 'settings.json');
 
   try {
     const fileStat = await stat(settingsPath);

--- a/scripts/widgets/model.ts
+++ b/scripts/widgets/model.ts
@@ -6,6 +6,7 @@
  * Fast mode: Opus 4.7/4.8 exclusive feature, indicated by ↯ symbol
  * @handbook 3.3-widget-data-sources
  * @tested scripts/__tests__/widgets.test.ts
+ * @tested scripts/__tests__/model-settings.test.ts
  */
 
 import { readFile, stat } from 'fs/promises';
@@ -62,7 +63,16 @@ export function getDefaultEffort(_modelId: string): EffortLevel {
   return 'high';
 }
 
-let settingsCache: { rawEffort: unknown; fastMode: boolean; mtime: number } | null = null;
+/**
+ * Path is part of the cache key because CLAUDE_CONFIG_DIR can switch
+ * mid-process and mtime alone can collide across directories.
+ */
+let settingsCache: {
+  rawEffort: unknown;
+  fastMode: boolean;
+  path: string;
+  mtime: number;
+} | null = null;
 
 async function getModelSettings(modelId: string): Promise<ModelSettings> {
   const defaultEffort = getDefaultEffort(modelId);
@@ -70,7 +80,11 @@ async function getModelSettings(modelId: string): Promise<ModelSettings> {
 
   try {
     const fileStat = await stat(settingsPath);
-    if (settingsCache && settingsCache.mtime === fileStat.mtimeMs) {
+    if (
+      settingsCache &&
+      settingsCache.path === settingsPath &&
+      settingsCache.mtime === fileStat.mtimeMs
+    ) {
       return {
         effortLevel: isEffortLevel(settingsCache.rawEffort) ? settingsCache.rawEffort : defaultEffort,
         fastMode: settingsCache.fastMode,
@@ -80,7 +94,7 @@ async function getModelSettings(modelId: string): Promise<ModelSettings> {
     const settings = JSON.parse(content);
     const rawEffort = settings.effortLevel;
     const fastMode = settings.fastMode === true;
-    settingsCache = { mtime: fileStat.mtimeMs, rawEffort, fastMode };
+    settingsCache = { path: settingsPath, mtime: fileStat.mtimeMs, rawEffort, fastMode };
     return {
       effortLevel: isEffortLevel(rawEffort) ? rawEffort : defaultEffort,
       fastMode,


### PR DESCRIPTION
## Summary

- The statusline and the plugin's command layer hardcoded `~/.claude`, ignoring the `CLAUDE_CONFIG_DIR` environment variable Claude Code uses to relocate its config directory. In multi-account setups the session read the *wrong* account's credentials/settings/history, and `/claude-dashboard:setup` registered the status line into the wrong account's `settings.json`.
- Centralizes path resolution in `scripts/utils/config-dir.ts` and migrates all TypeScript call sites; every executable snippet in `commands/*.md` and the README now resolves the same rule.
- Hardens the three config-file caches (credentials, history, model settings) to key by resolved path, so a mid-process `CLAUDE_CONFIG_DIR` switch can no longer serve stale data on mtime/size collisions.
- Adds a doc-snippet test suite that extracts the shipped one-liners from the markdown and executes them in a sandbox — the docs can't silently drift from the behavior again.

## Changes

**Path resolution (`scripts/utils/config-dir.ts`, new)**
- `getClaudeConfigDir()` — resolves the config dir for `.credentials.json`, `settings.json`, `history.jsonl`. Uses `||` (not `??`) so an empty `CLAUDE_CONFIG_DIR` falls back to `~/.claude` instead of a CWD-relative path.
- `getClaudeJsonPath()` — `.claude.json`'s asymmetric rule: beside `$HOME` by default, but *inside* the directory when `CLAUDE_CONFIG_DIR` is set.
- Defaults hoisted to module constants (home cannot change mid-process; only the env var is read at call time).
- Call sites migrated: `utils/credentials.ts`, `widgets/model.ts`, `utils/history-parser.ts`, `widgets/config-counts.ts`.

**Path-keyed caches**
- `credentials.ts` (path+mtime), `history-parser.ts` (path+fileSize), `model.ts` settings cache (path+mtime).
- Each gains a collision-reproducing test: `utimes`-forced identical mtimes, equal-byte-length history files.

**Command layer (`commands/*.md`, README)**
- Every snippet in `setup.md`, `update.md`, `check-usage.md`, `setup-alias.md`, and the README manual-install clone resolves `${CLAUDE_CONFIG_DIR:-$HOME/.claude}` once in bash and passes it to the embedded `node -e` via env — no duplicated JS-side fallback.
- The `check-ai` alias resolves per invocation, so per-shell account switching just works.
- PowerShell branch mirrors the rule (statically reviewed; no pwsh available on the dev machine).

**Intentional exception**
- `claude-dashboard.local.json` stays on `~/.claude`: it is the dashboard's own display config, shared across accounts. Documented in `setup.md`, README, and a code comment in `statusline.ts`.

## Test plan

- [x] 513 tests green (`npx vitest run`), including 4 collision tests and the 7-test doc-snippet suite
- [x] Doc snippets extracted from the shipped markdown and executed against sandbox fixtures — default / relocated / empty-env / per-account isolation all observed
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` — `dist/` rebuilt and committed
- [x] Single-account behavior unchanged when `CLAUDE_CONFIG_DIR` is unset (regression guard)

Closes #81