### PR TITLE
fix: restrict the @claude trigger to repository insiders

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,23 @@ on:
 
 jobs:
   claude:
+    # Insiders only. Every trigger here fires in the base-repo context, so the run gets
+    # CLAUDE_CODE_OAUTH_TOKEN and a write token even when the pull request comes from a
+    # fork — without an author check, any GitHub user could start one by writing "@claude".
+    # author_association lives on a different object per event, hence the repetition.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- `claude.yml`'s four triggers (`issue_comment`, `pull_request_review_comment`, `pull_request_review`, `issues`) all fire in the base-repo context, so a run gets `CLAUDE_CODE_OAUTH_TOKEN` and a write token even when the pull request comes from a fork.
- There was no author check, so any GitHub user could start such a run just by writing `@claude` in a comment, review, or issue.
- Each branch now additionally requires `author_association` to be one of `OWNER`, `MEMBER`, or `COLLABORATOR`.

## Changes

`author_association` lives on a different object per event (`comment` / `review` / `issue`), so the check is written per branch rather than hoisted. The values are only read inside the `if:` expression — nothing reaches a `run:` shell, so no injection surface is added.

## Test plan

- [x] `claude.yml` parses as valid YAML
- [x] All 4 event branches carry an `author_association` check
- [x] No `run:` step interpolates event body/title
- [ ] Outside contributor commenting `@claude` no longer starts a run (verify on the next fork PR)
- [ ] Maintainer commenting `@claude` still starts a run (verify after merge)