### PR TITLE
fix: restore the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=uppinote20/claude-dashboard&type=Date)](https://star-history.com/#uppinote20/claude-dashboard&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=uppinote20/claude-dashboard&type=Date)](https://star-history.dera.page/#uppinote20/claude-dashboard&Date)
 
 ## ☕ Support
 


### PR DESCRIPTION
The star history chart in the README is currently broken and no longer shows up-to-date stargazer data. This PR updates the chart image and its link to a working instance of the same service so the project's star growth renders correctly again.