### PR TITLE
fix(model): read per-model effortLevel from modelSettings

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1182,6 +1182,17 @@ function getDefaultEffort(_modelId) {
   return "high";
 }
 var settingsCache = null;
+function resolveEffort(rawModelSettings, rawEffort, modelId, defaultEffort) {
+  if (rawModelSettings && typeof rawModelSettings === "object" && modelId) {
+    const perModel = rawModelSettings[modelId];
+    if (perModel && typeof perModel === "object") {
+      const candidate = perModel.effortLevel;
+      if (isEffortLevel(candidate))
+        return candidate;
+    }
+  }
+  return isEffortLevel(rawEffort) ? rawEffort : defaultEffort;
+}
 async function getModelSettings(modelId) {
   const defaultEffort = getDefaultEffort(modelId);
   const settingsPath = join3(getClaudeConfigDir(), "settings.json");
@@ -1189,17 +1200,29 @@ async function getModelSettings(modelId) {
     const fileStat = await stat3(settingsPath);
     if (settingsCache && settingsCache.path === settingsPath && settingsCache.mtime === fileStat.mtimeMs) {
       return {
-        effortLevel: isEffortLevel(settingsCache.rawEffort) ? settingsCache.rawEffort : defaultEffort,
+        effortLevel: resolveEffort(
+          settingsCache.rawModelSettings,
+          settingsCache.rawEffort,
+          modelId,
+          defaultEffort
+        ),
         fastMode: settingsCache.fastMode
       };
     }
     const content = await readFile3(settingsPath, "utf-8");
     const settings = JSON.parse(content);
     const rawEffort = settings.effortLevel;
+    const rawModelSettings = settings.modelSettings;
     const fastMode = settings.fastMode === true;
-    settingsCache = { path: settingsPath, mtime: fileStat.mtimeMs, rawEffort, fastMode };
+    settingsCache = {
+      path: settingsPath,
+      mtime: fileStat.mtimeMs,
+      rawEffort,
+      rawModelSettings,
+      fastMode
+    };
     return {
-      effortLevel: isEffortLevel(rawEffort) ? rawEffort : defaultEffort,
+      effortLevel: resolveEffort(rawModelSettings, rawEffort, modelId, defaultEffort),
       fastMode
     };
   } catch {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1182,12 +1182,27 @@ function getDefaultEffort(_modelId) {
   return "high";
 }
 var settingsCache = null;
+function normalizeModelId(modelId) {
+  return modelId.replace(/\[1m\]$/i, "").toLowerCase();
+}
+function effortOf(perModel) {
+  if (!perModel || typeof perModel !== "object")
+    return void 0;
+  const candidate = perModel.effortLevel;
+  return isEffortLevel(candidate) ? candidate : void 0;
+}
 function resolveEffort(rawModelSettings, rawEffort, modelId, defaultEffort) {
   if (rawModelSettings && typeof rawModelSettings === "object" && modelId) {
-    const perModel = rawModelSettings[modelId];
-    if (perModel && typeof perModel === "object") {
-      const candidate = perModel.effortLevel;
-      if (isEffortLevel(candidate))
+    const entries = rawModelSettings;
+    const exact = effortOf(entries[modelId]);
+    if (exact)
+      return exact;
+    const wanted = normalizeModelId(modelId);
+    for (const [key, perModel] of Object.entries(entries)) {
+      if (normalizeModelId(key) !== wanted)
+        continue;
+      const candidate = effortOf(perModel);
+      if (candidate)
         return candidate;
     }
   }

--- a/scripts/__tests__/model-settings.test.ts
+++ b/scripts/__tests__/model-settings.test.ts
@@ -113,4 +113,33 @@ describe('model settings (getData)', () => {
     const opusCtx = { stdin: { model: { id: 'claude-opus-4-8' } } } as unknown as WidgetContext;
     expect((await modelWidget.getData(opusCtx))?.effortLevel).toBe('max');
   });
+
+  it('should match the per-model entry when stdin carries the [1m] context suffix', async () => {
+    // `/effort` strips `[1m]` before keying modelSettings, but the status line's
+    // `model.id` keeps it for 1M-context sessions
+    await writeFile(SETTINGS_FILE, JSON.stringify({
+      effortLevel: 'high',
+      modelSettings: { 'claude-fable-5': { effortLevel: 'medium' } },
+    }));
+
+    const { modelWidget } = await import('../widgets/model.js');
+    const oneMCtx = { stdin: { model: { id: 'claude-fable-5[1m]' } } } as unknown as WidgetContext;
+
+    expect((await modelWidget.getData(oneMCtx))?.effortLevel).toBe('medium');
+  });
+
+  it('should prefer an exact modelSettings key over a suffix-normalized match', async () => {
+    await writeFile(SETTINGS_FILE, JSON.stringify({
+      modelSettings: {
+        'claude-fable-5': { effortLevel: 'medium' },
+        'claude-fable-5[1m]': { effortLevel: 'low' },
+      },
+    }));
+
+    const { modelWidget } = await import('../widgets/model.js');
+    const oneMCtx = { stdin: { model: { id: 'claude-fable-5[1m]' } } } as unknown as WidgetContext;
+
+    expect((await modelWidget.getData(oneMCtx))?.effortLevel).toBe('low');
+    expect((await modelWidget.getData(ctx))?.effortLevel).toBe('medium');
+  });
 });

--- a/scripts/__tests__/model-settings.test.ts
+++ b/scripts/__tests__/model-settings.test.ts
@@ -71,6 +71,7 @@ describe('model settings (getData)', () => {
     process.env.CLAUDE_CONFIG_DIR = ALT_CONFIG_DIR;
     expect((await modelWidget.getData(ctx))?.effortLevel).toBe('max');
   });
+
   it('should prefer the per-model effortLevel in modelSettings over the top-level key', async () => {
     // `/effort` writes per-model settings; the legacy top-level key may hold a stale value
     await writeFile(SETTINGS_FILE, JSON.stringify({

--- a/scripts/__tests__/model-settings.test.ts
+++ b/scripts/__tests__/model-settings.test.ts
@@ -71,4 +71,46 @@ describe('model settings (getData)', () => {
     process.env.CLAUDE_CONFIG_DIR = ALT_CONFIG_DIR;
     expect((await modelWidget.getData(ctx))?.effortLevel).toBe('max');
   });
+  it('should prefer the per-model effortLevel in modelSettings over the top-level key', async () => {
+    // `/effort` writes per-model settings; the legacy top-level key may hold a stale value
+    await writeFile(SETTINGS_FILE, JSON.stringify({
+      effortLevel: 'high',
+      modelSettings: {
+        'claude-opus-4-8': { effortLevel: 'high' },
+        'claude-fable-5': { effortLevel: 'medium' },
+      },
+    }));
+
+    const { modelWidget } = await import('../widgets/model.js');
+    const data = await modelWidget.getData(ctx);
+
+    expect(data?.effortLevel).toBe('medium');
+  });
+
+  it('should fall back to the top-level effortLevel when modelSettings has no entry for the model', async () => {
+    await writeFile(SETTINGS_FILE, JSON.stringify({
+      effortLevel: 'low',
+      modelSettings: { 'claude-opus-4-8': { effortLevel: 'max' } },
+    }));
+
+    const { modelWidget } = await import('../widgets/model.js');
+    const data = await modelWidget.getData(ctx);
+
+    expect(data?.effortLevel).toBe('low');
+  });
+
+  it('should resolve per-model effort for a different model id without a stale cache hit', async () => {
+    await writeFile(SETTINGS_FILE, JSON.stringify({
+      modelSettings: {
+        'claude-opus-4-8': { effortLevel: 'max' },
+        'claude-fable-5': { effortLevel: 'medium' },
+      },
+    }));
+
+    const { modelWidget } = await import('../widgets/model.js');
+    expect((await modelWidget.getData(ctx))?.effortLevel).toBe('medium');
+
+    const opusCtx = { stdin: { model: { id: 'claude-opus-4-8' } } } as unknown as WidgetContext;
+    expect((await modelWidget.getData(opusCtx))?.effortLevel).toBe('max');
+  });
 });

--- a/scripts/widgets/model.ts
+++ b/scripts/widgets/model.ts
@@ -77,11 +77,29 @@ let settingsCache: {
 } | null = null;
 
 /**
+ * Claude Code keys `modelSettings` by the model id with the `[1m]` context-window
+ * suffix stripped (and compares case-insensitively), while the status line's
+ * `model.id` keeps that suffix for 1M-context sessions — so both sides are
+ * normalized the same way before they're compared.
+ */
+function normalizeModelId(modelId: string): string {
+  return modelId.replace(/\[1m\]$/i, '').toLowerCase();
+}
+
+/** The validated `effortLevel` of one `modelSettings` entry, if it has one. */
+function effortOf(perModel: unknown): EffortLevel | undefined {
+  if (!perModel || typeof perModel !== 'object') return undefined;
+  const candidate = (perModel as Record<string, unknown>).effortLevel;
+  return isEffortLevel(candidate) ? candidate : undefined;
+}
+
+/**
  * Resolve the effort tier for `modelId` from a parsed settings.json.
  * `/effort` writes per-model values to `modelSettings[<model id>].effortLevel`
  * (the top-level `effortLevel` is the legacy global key and may hold a stale
  * value once per-model settings exist), so per-model wins, then top-level,
- * then the default.
+ * then the default. Within `modelSettings` an exact key wins over a
+ * suffix-normalized match, mirroring Claude Code's own lookup order.
  */
 function resolveEffort(
   rawModelSettings: unknown,
@@ -90,10 +108,14 @@ function resolveEffort(
   defaultEffort: EffortLevel
 ): EffortLevel {
   if (rawModelSettings && typeof rawModelSettings === 'object' && modelId) {
-    const perModel = (rawModelSettings as Record<string, unknown>)[modelId];
-    if (perModel && typeof perModel === 'object') {
-      const candidate = (perModel as Record<string, unknown>).effortLevel;
-      if (isEffortLevel(candidate)) return candidate;
+    const entries = rawModelSettings as Record<string, unknown>;
+    const exact = effortOf(entries[modelId]);
+    if (exact) return exact;
+    const wanted = normalizeModelId(modelId);
+    for (const [key, perModel] of Object.entries(entries)) {
+      if (normalizeModelId(key) !== wanted) continue;
+      const candidate = effortOf(perModel);
+      if (candidate) return candidate;
     }
   }
   return isEffortLevel(rawEffort) ? rawEffort : defaultEffort;

--- a/scripts/widgets/model.ts
+++ b/scripts/widgets/model.ts
@@ -46,8 +46,9 @@ interface ModelSettings {
 }
 
 /**
- * Fallback effort used only when the user has never set one — no `effortLevel`
- * in settings.json and no `CLAUDE_CODE_EFFORT_LEVEL` override. Claude Code's
+ * Fallback effort used only when the user has never set one — no per-model
+ * `modelSettings[<id>].effortLevel` or top-level `effortLevel` in settings.json
+ * and no `CLAUDE_CODE_EFFORT_LEVEL` override. Claude Code's
  * unset default is 'high' for every model the `/model` picker exposes (Opus 4.8,
  * Sonnet 5, Fable 5; Haiku has no effort tier, so render() hides its badge), so
  * this returns 'high'.
@@ -69,10 +70,34 @@ export function getDefaultEffort(_modelId: string): EffortLevel {
  */
 let settingsCache: {
   rawEffort: unknown;
+  rawModelSettings: unknown;
   fastMode: boolean;
   path: string;
   mtime: number;
 } | null = null;
+
+/**
+ * Resolve the effort tier for `modelId` from a parsed settings.json.
+ * `/effort` writes per-model values to `modelSettings[<model id>].effortLevel`
+ * (the top-level `effortLevel` is the legacy global key and may hold a stale
+ * value once per-model settings exist), so per-model wins, then top-level,
+ * then the default.
+ */
+function resolveEffort(
+  rawModelSettings: unknown,
+  rawEffort: unknown,
+  modelId: string,
+  defaultEffort: EffortLevel
+): EffortLevel {
+  if (rawModelSettings && typeof rawModelSettings === 'object' && modelId) {
+    const perModel = (rawModelSettings as Record<string, unknown>)[modelId];
+    if (perModel && typeof perModel === 'object') {
+      const candidate = (perModel as Record<string, unknown>).effortLevel;
+      if (isEffortLevel(candidate)) return candidate;
+    }
+  }
+  return isEffortLevel(rawEffort) ? rawEffort : defaultEffort;
+}
 
 async function getModelSettings(modelId: string): Promise<ModelSettings> {
   const defaultEffort = getDefaultEffort(modelId);
@@ -86,17 +111,29 @@ async function getModelSettings(modelId: string): Promise<ModelSettings> {
       settingsCache.mtime === fileStat.mtimeMs
     ) {
       return {
-        effortLevel: isEffortLevel(settingsCache.rawEffort) ? settingsCache.rawEffort : defaultEffort,
+        effortLevel: resolveEffort(
+          settingsCache.rawModelSettings,
+          settingsCache.rawEffort,
+          modelId,
+          defaultEffort
+        ),
         fastMode: settingsCache.fastMode,
       };
     }
     const content = await readFile(settingsPath, 'utf-8');
     const settings = JSON.parse(content);
     const rawEffort = settings.effortLevel;
+    const rawModelSettings = settings.modelSettings;
     const fastMode = settings.fastMode === true;
-    settingsCache = { path: settingsPath, mtime: fileStat.mtimeMs, rawEffort, fastMode };
+    settingsCache = {
+      path: settingsPath,
+      mtime: fileStat.mtimeMs,
+      rawEffort,
+      rawModelSettings,
+      fastMode,
+    };
     return {
-      effortLevel: isEffortLevel(rawEffort) ? rawEffort : defaultEffort,
+      effortLevel: resolveEffort(rawModelSettings, rawEffort, modelId, defaultEffort),
       fastMode,
     };
   } catch {


### PR DESCRIPTION
## Summary

Claude Code's `/effort` now persists the effort tier **per model** under `modelSettings[<model id>].effortLevel`. The top-level `effortLevel` key is the legacy global value and goes stale once per-model settings exist. The model widget only read the top-level key, so the badge kept showing the old tier after switching.

Repro (Claude Code with Fable 5): `/effort medium` writes

```json
"effortLevel": "high",
"modelSettings": { "claude-fable-5": { "effortLevel": "medium" } }
```

and the status line still rendered `Fable(H)`.

## Changes

- `scripts/widgets/model.ts`: add `resolveEffort()` — precedence is `modelSettings[modelId].effortLevel` → top-level `effortLevel` → default. The settings cache now also keeps the raw `modelSettings` map so cache hits resolve per-model correctly (including when the model id changes between calls).
- `scripts/__tests__/model-settings.test.ts`: 3 new tests — per-model wins over top-level, top-level fallback when the model has no entry, per-model resolution across different model ids on a cache hit.
- `dist/index.js`: rebuilt.

## Test Plan

- [x] Tested locally with `npm run test` — `model-settings.test.ts` 5/5 pass (2 new tests fail before the fix, pass after). Remaining failures on my machine are pre-existing Windows-only cases (`0o600` perms, `\` path separator, shim syntax), untouched by this PR.
- [x] Verified status line output format — piped stdin with `model.id = "claude-fable-5"`, badge follows `modelSettings` (`Fable(M)` / `Fable(L)` as the tier changes).
- [ ] Checked i18n (en/ko) — no user-facing strings changed.

## Screenshots (if applicable)

N/A (single badge character change: `Fable(H)` → `Fable(M)`).
