### PR TITLE
fix(ci): bypass the OIDC exchange in the fork review workflow

### DIFF
--- a/.github/workflows/claude-code-review-fork.yml
+++ b/.github/workflows/claude-code-review-fork.yml
@@ -19,6 +19,13 @@ name: Claude Code Review (fork)
 # That is why `synchronize` does NOT re-review. It revokes instead: a push drops the
 # label, and a maintainer must read the new head and re-apply it. Auto-reviewing on push
 # would let a contributor get a benign diff approved and then push an injected one.
+#
+# Authentication: by default the action exchanges the job's OIDC token for a Claude GitHub
+# App token, and Anthropic's exchange endpoint rejects tokens minted under
+# `pull_request_target` (401 "Invalid OIDC token" on every labeled run). Passing
+# `github_token` skips that exchange, so the review is posted by `github-actions[bot]`
+# rather than `claude[bot]`, and the job does not grant `id-token: write` because nothing
+# in it requests an OIDC token any more.
 on:
   pull_request_target:
     types: [labeled, synchronize]
@@ -71,7 +78,6 @@ jobs:
       contents: read
       pull-requests: write
       issues: read
-      id-token: write
 
     steps:
       # No `ref:` here, on purpose. Under pull_request_target the default is the base
@@ -87,6 +93,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
           prompt: |


### PR DESCRIPTION
## Summary

- The label-gated fork review (`pull_request_target`) failed on every run with `App token exchange failed: 401 Unauthorized - Invalid OIDC token` (runs 32217849919 on #90 and 32614099300 on #91); the `if:` gate itself was passing.
- Anthropic's OIDC → GitHub App token exchange rejects tokens minted under `pull_request_target`, so the job now passes `github_token: ${{ secrets.GITHUB_TOKEN }}`, which skips the exchange entirely (the documented escape hatch).
- `id-token: write` is dropped from the job — nothing requests an OIDC token any more, and leaving it would only expose the OIDC request env vars to the agent.
- Side effect: the review is posted by `github-actions[bot]` instead of `claude[bot]`. `pull-requests: write` is sufficient for `gh pr comment` (the issue-comment endpoint is listed under both the Issues and Pull requests permissions).

## Test plan

- [x] YAML parses; `npm run build` + `npm test` (601 passed) unaffected
- [ ] After merge: remove and re-apply `safe-to-review` on #91 and confirm the `claude-review-fork` job posts a review
