### PR TITLE
fix(model): let CLAUDE_CODE_EFFORT_LEVEL override settings.json

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1210,12 +1210,14 @@ function resolveEffort(rawModelSettings, rawEffort, modelId, defaultEffort) {
 }
 async function getModelSettings(modelId) {
   const defaultEffort = getDefaultEffort(modelId);
+  const envEffort = process.env.CLAUDE_CODE_EFFORT_LEVEL;
+  const envOverride = isEffortLevel(envEffort) ? envEffort : void 0;
   const settingsPath = join3(getClaudeConfigDir(), "settings.json");
   try {
     const fileStat = await stat3(settingsPath);
     if (settingsCache && settingsCache.path === settingsPath && settingsCache.mtime === fileStat.mtimeMs) {
       return {
-        effortLevel: resolveEffort(
+        effortLevel: envOverride ?? resolveEffort(
           settingsCache.rawModelSettings,
           settingsCache.rawEffort,
           modelId,
@@ -1237,17 +1239,13 @@ async function getModelSettings(modelId) {
       fastMode
     };
     return {
-      effortLevel: resolveEffort(rawModelSettings, rawEffort, modelId, defaultEffort),
+      effortLevel: envOverride ?? resolveEffort(rawModelSettings, rawEffort, modelId, defaultEffort),
       fastMode
     };
   } catch {
     settingsCache = null;
   }
-  const envEffort = process.env.CLAUDE_CODE_EFFORT_LEVEL;
-  if (isEffortLevel(envEffort)) {
-    return { effortLevel: envEffort, fastMode: false };
-  }
-  return { effortLevel: defaultEffort, fastMode: false };
+  return { effortLevel: envOverride ?? defaultEffort, fastMode: false };
 }
 var modelWidget = {
   id: "model",

--- a/scripts/__tests__/model-settings.test.ts
+++ b/scripts/__tests__/model-settings.test.ts
@@ -143,4 +143,25 @@ describe('model settings (getData)', () => {
     expect((await modelWidget.getData(oneMCtx))?.effortLevel).toBe('low');
     expect((await modelWidget.getData(ctx))?.effortLevel).toBe('medium');
   });
+
+  it('should let CLAUDE_CODE_EFFORT_LEVEL override settings.json like Claude Code does', async () => {
+    await writeFile(SETTINGS_FILE, JSON.stringify({
+      effortLevel: 'high',
+      modelSettings: { 'claude-fable-5': { effortLevel: 'medium' } },
+    }));
+    process.env.CLAUDE_CODE_EFFORT_LEVEL = 'low';
+
+    const { modelWidget } = await import('../widgets/model.js');
+
+    expect((await modelWidget.getData(ctx))?.effortLevel).toBe('low');
+  });
+
+  it('should ignore an invalid CLAUDE_CODE_EFFORT_LEVEL and fall through to settings.json', async () => {
+    await writeFile(SETTINGS_FILE, JSON.stringify({ effortLevel: 'high' }));
+    process.env.CLAUDE_CODE_EFFORT_LEVEL = 'turbo';
+
+    const { modelWidget } = await import('../widgets/model.js');
+
+    expect((await modelWidget.getData(ctx))?.effortLevel).toBe('high');
+  });
 });

--- a/scripts/__tests__/model-settings.test.ts
+++ b/scripts/__tests__/model-settings.test.ts
@@ -164,4 +164,14 @@ describe('model settings (getData)', () => {
 
     expect((await modelWidget.getData(ctx))?.effortLevel).toBe('high');
   });
+
+  it('should apply CLAUDE_CODE_EFFORT_LEVEL on a settings cache hit too', async () => {
+    await writeFile(SETTINGS_FILE, JSON.stringify({ effortLevel: 'high' }));
+
+    const { modelWidget } = await import('../widgets/model.js');
+    expect((await modelWidget.getData(ctx))?.effortLevel).toBe('high'); // fills the cache
+
+    process.env.CLAUDE_CODE_EFFORT_LEVEL = 'low';
+    expect((await modelWidget.getData(ctx))?.effortLevel).toBe('low'); // same mtime → cache hit
+  });
 });

--- a/scripts/widgets/model.ts
+++ b/scripts/widgets/model.ts
@@ -123,6 +123,9 @@ function resolveEffort(
 
 async function getModelSettings(modelId: string): Promise<ModelSettings> {
   const defaultEffort = getDefaultEffort(modelId);
+  // Same precedence as Claude Code: a valid env override beats settings.json
+  const envEffort = process.env.CLAUDE_CODE_EFFORT_LEVEL;
+  const envOverride = isEffortLevel(envEffort) ? envEffort : undefined;
   const settingsPath = join(getClaudeConfigDir(), 'settings.json');
 
   try {
@@ -133,7 +136,7 @@ async function getModelSettings(modelId: string): Promise<ModelSettings> {
       settingsCache.mtime === fileStat.mtimeMs
     ) {
       return {
-        effortLevel: resolveEffort(
+        effortLevel: envOverride ?? resolveEffort(
           settingsCache.rawModelSettings,
           settingsCache.rawEffort,
           modelId,
@@ -155,19 +158,14 @@ async function getModelSettings(modelId: string): Promise<ModelSettings> {
       fastMode,
     };
     return {
-      effortLevel: resolveEffort(rawModelSettings, rawEffort, modelId, defaultEffort),
+      effortLevel: envOverride ?? resolveEffort(rawModelSettings, rawEffort, modelId, defaultEffort),
       fastMode,
     };
   } catch {
     settingsCache = null;
   }
 
-  const envEffort = process.env.CLAUDE_CODE_EFFORT_LEVEL;
-  if (isEffortLevel(envEffort)) {
-    return { effortLevel: envEffort, fastMode: false };
-  }
-
-  return { effortLevel: defaultEffort, fastMode: false };
+  return { effortLevel: envOverride ?? defaultEffort, fastMode: false };
 }
 
 export const modelWidget: Widget<ModelData> = {


### PR DESCRIPTION
## Summary

- `getModelSettings()` only consulted `CLAUDE_CODE_EFFORT_LEVEL` in the `catch` path, so whenever `settings.json` existed the env var was ignored and the badge could disagree with the session's actual effort.
- The env var now takes precedence over both `modelSettings[<id>].effortLevel` and the top-level `effortLevel` when it holds a valid tier, matching Claude Code's own resolution order; invalid values fall through to settings, then the default.
- `fastMode` is unaffected and still comes from the file.

## Test plan

- [x] New tests: env overrides file; invalid env falls through (`model-settings.test.ts`, 9/9)
- [x] `npm test` 608 passed, `tsc --noEmit` clean, `dist/index.js` rebuilt

Closes #93
